### PR TITLE
feat(image-optimizer): wasm-vips based local image optimizer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,12 +38,12 @@
         "ttf2woff2": "^8.0.1",
         "tunnel-rat": "^0.1.2",
         "valibot": "^1.3.1",
+        "wasm-vips": "^0.0.17",
         "zustand": "^5.0.12",
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.28.5",
         "@react-router/dev": "^7.14.0",
-        "@responsive-image/vite-plugin": "^3.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.2",
@@ -416,56 +416,6 @@
 
     "@iarna/toml": ["@iarna/toml@2.2.3", "", {}, "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg=="],
 
-    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
-
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
-
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
-
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
-
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
-
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
-
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
-
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
@@ -720,13 +670,9 @@
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.0", "", {}, "sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA=="],
 
-    "@responsive-image/build-utils": ["@responsive-image/build-utils@3.0.0", "", { "dependencies": { "@responsive-image/core": "^2.1.0", "@rollup/pluginutils": "^5.1.0", "base-n": "^3.0.0", "imagetools-core": "^9.0.0", "javascript-stringify": "^2.1.0", "sharp": "^0.34.0" } }, "sha512-QskyMELPG4BXY9ak3KqHH4Jd66Cm1EU4OP6i2EpnZVdn6J0vc6BrVcXkPB/ToTNp+09PrAj30bTV35XLBy+06w=="],
-
     "@responsive-image/core": ["@responsive-image/core@2.1.0", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" }, "peerDependencies": { "blurhash": "^2.0.0", "thumbhash": "^0.1.1" }, "optionalPeers": ["blurhash", "thumbhash"] }, "sha512-UH1sLdoPVhLoKQC9tjFmhq+m2y1dknMETQ7VeX3gu98XRElz1bxNlx8ahy73H74452MyrlsyIzODyA58NkYfBQ=="],
 
     "@responsive-image/react": ["@responsive-image/react@1.1.6", "", { "dependencies": { "@responsive-image/core": "^2.1.0" }, "peerDependencies": { "react": "18.x || 19.x", "react-dom": "18.x || 19.x" } }, "sha512-3FhWpt48kJ1lkbc8Qd1AxbK404x9RURw+mYzCaAhz82CZH536AeBgou+DQL1csyf0SMrsjz1KgQAqzdzfk0BZA=="],
-
-    "@responsive-image/vite-plugin": ["@responsive-image/vite-plugin@3.0.0", "", { "dependencies": { "@responsive-image/build-utils": "^3.0.0", "@responsive-image/core": "^2.1.0", "blurhash": "^2.0.4", "imagetools-core": "^9.0.0", "sharp": "^0.34.0", "thumbhash": "^0.1.1" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-FsHd3unyljKSS6lJKXo/hrpwvtPIoq8TU9R2f/+WW9BC/6pN1VeaCjAvuo61Uc5+aBIFt61PsMt0naqi7CL6Qg=="],
 
     "@rexxars/jiti": ["@rexxars/jiti@2.6.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-B9FdXL9Z+TnaT+H1Z91nd68tjaD5q3G0ZC7e1Se3/rUur70DSZj++54HhkfoNIA5n/Y1TMllKKGk9qYsOVK2Lw=="],
 
@@ -1122,8 +1068,6 @@
 
     "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
 
-    "assert-plus": ["assert-plus@1.0.0", "", {}, "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="],
-
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -1155,8 +1099,6 @@
     "bare-stream": ["bare-stream@2.10.0", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-buffer", "bare-events"] }, "sha512-DOPZF/DDcDruKDA43cOw6e9Quq5daua7ygcAwJE/pKJsRWhgSSemi7qVNGE5kyDIxIeN1533G/zfbvWX7Wcb9w=="],
 
     "bare-url": ["bare-url@2.4.0", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA=="],
-
-    "base-n": ["base-n@3.0.0", "", { "dependencies": { "dashdash": "^1.14.1" }, "bin": { "base-n": "bin/cli.js" } }, "sha512-u+HQjUyXwqZLbDDlunZUoFlWSZWIwIpNpDErBMOCkBU/VOMpVYMLYih/+FRFCkfrgXrdnbI46fTkUIu1C22v7Q=="],
 
     "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
@@ -1305,8 +1247,6 @@
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "custom-media-element": ["custom-media-element@1.4.6", "", {}, "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA=="],
-
-    "dashdash": ["dashdash@1.14.1", "", { "dependencies": { "assert-plus": "^1.0.0" } }, "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g=="],
 
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
@@ -1584,8 +1524,6 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "imagetools-core": ["imagetools-core@9.1.0", "", {}, "sha512-xQjs+2vrxLnAjCq+omuNkd5UQTld9/bP8+YT0LyYTlKfuSQtgUBvqhUwGugzSAh6sCdN+LnROMuLswn5hZ9Fhg=="],
-
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -1675,8 +1613,6 @@
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
-
-    "javascript-stringify": ["javascript-stringify@2.1.0", "", {}, "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -2128,8 +2064,6 @@
 
     "shallowequal": ["shallowequal@1.1.0", "", {}, "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -2367,6 +2301,8 @@
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "wasm-vips": ["wasm-vips@0.0.17", "", {}, "sha512-nhkqUNJDUymImoXGrVfImC4wzIFTb9KfBpAngb7dcEQNPP1gVTx4+WL3VVVDSXQpMsyeacsQDOx0+DM33Rpurg=="],
 
     "web-vitals": ["web-vitals@5.1.0", "", {}, "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg=="],
 

--- a/lib/image-optimizer/cache.ts
+++ b/lib/image-optimizer/cache.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let cacheDir = "node_modules/.vite/.image-optimizer";
+
+export function setCacheDir(dir: string) {
+  cacheDir = dir;
+}
+
+function ensureCacheDir() {
+  if (!existsSync(cacheDir)) {
+    mkdirSync(cacheDir, { recursive: true });
+  }
+}
+
+function wasmVipsVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("wasm-vips/package.json") as { version: string };
+    return pkg.version;
+  } catch {
+    return "unknown";
+  }
+}
+
+export function cacheKey(sourceBytes: Uint8Array, params: string): string {
+  return createHash("sha256")
+    .update(sourceBytes)
+    .update(params)
+    .update(wasmVipsVersion())
+    .digest("hex");
+}
+
+export function readCache(key: string, ext: string): Uint8Array | null {
+  const path = join(cacheDir, `${key}.${ext}`);
+  if (existsSync(path)) return new Uint8Array(readFileSync(path));
+  return null;
+}
+
+export function writeCache(key: string, ext: string, bytes: Uint8Array) {
+  ensureCacheDir();
+  writeFileSync(join(cacheDir, `${key}.${ext}`), bytes);
+}

--- a/lib/image-optimizer/index.ts
+++ b/lib/image-optimizer/index.ts
@@ -1,0 +1,2 @@
+export { imageOptimizer } from "./plugin.ts";
+export type { ImageData, ImageType, ImageTypeAuto, Lqip, ImageOptimizerOptions } from "./types.ts";

--- a/lib/image-optimizer/lqip.ts
+++ b/lib/image-optimizer/lqip.ts
@@ -1,0 +1,44 @@
+import { initVips } from "./process.ts";
+
+/**
+ * Generate an inline SVG LQIP (Low Quality Image Placeholder) as a data URI.
+ * Returns a "data:image/svg+xml;base64,..." string suitable for use as a
+ * CSS background-image value.
+ */
+export async function generateInlineLqip(
+  bytes: Uint8Array,
+  origWidth: number,
+  origHeight: number,
+): Promise<string> {
+  const vips = await initVips();
+  const img = vips.Image.newFromBuffer(bytes);
+  const tiny = img.thumbnailImage(16);
+
+  try {
+    // Always encode as PNG for LQIP (handles alpha, ~200B at 16px)
+    const tinyPngBytes = tiny.writeToBuffer(".png");
+    const tinyB64 = Buffer.from(tinyPngBytes).toString("base64");
+    const tinyDataUri = `data:image/png;base64,${tinyB64}`;
+
+    // Build SVG with feGaussianBlur filter
+    const svg = [
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"`,
+      ` viewBox="0 0 ${origWidth} ${origHeight}">`,
+      `<filter id="b"><feGaussianBlur stdDeviation="20" /></filter>`,
+      `<image`,
+      ` x="0" y="0"`,
+      ` width="${origWidth}" height="${origHeight}"`,
+      ` filter="url(#b)"`,
+      ` preserveAspectRatio="none"`,
+      ` href="${tinyDataUri}"`,
+      `/>`,
+      `</svg>`,
+    ].join("");
+
+    const svgB64 = Buffer.from(svg).toString("base64");
+    return `data:image/svg+xml;base64,${svgB64}`;
+  } finally {
+    img.delete();
+    tiny.delete();
+  }
+}

--- a/lib/image-optimizer/package.json
+++ b/lib/image-optimizer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@darkroom/image-optimizer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {
+    "wasm-vips": "^0.0.17"
+  },
+  "peerDependencies": {
+    "vite": ">=5.0.0"
+  }
+}

--- a/lib/image-optimizer/plugin.ts
+++ b/lib/image-optimizer/plugin.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { Plugin } from "vite";
+import { cacheKey, readCache, setCacheDir, writeCache } from "./cache.ts";
+import { generateInlineLqip } from "./lqip.ts";
+import { getMetadata, resizeAndEncode } from "./process.ts";
+import type { ImageOptimizerOptions } from "./types.ts";
+
+const QUERY_RE = /[?&]responsive(?:[&=]|$)/;
+const IMAGE_EXTS = new Set(["jpg", "jpeg", "png", "webp"]);
+const MIDDLEWARE_PREFIX = "/@image-optimizer/";
+
+function hasResponsiveQuery(id: string): boolean {
+  return QUERY_RE.test(id);
+}
+
+function idWithoutQuery(id: string): string {
+  const qIdx = id.indexOf("?");
+  return qIdx === -1 ? id : id.slice(0, qIdx);
+}
+
+function isImageExt(filePath: string): boolean {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_EXTS.has(ext);
+}
+
+// Sort formats in browser-preference order: avif > webp > jpeg/png
+function sortFormats(
+  formats: Array<"jpeg" | "png" | "webp" | "avif">,
+): Array<"jpeg" | "png" | "webp" | "avif"> {
+  const order: Record<string, number> = { avif: 0, webp: 1, jpeg: 2, png: 2 };
+  return [...formats].sort((a, b) => (order[a] ?? 3) - (order[b] ?? 3));
+}
+
+export function imageOptimizer(options: ImageOptimizerOptions = {}): Plugin {
+  const widths = options.widths ?? [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+  const formats = options.formats ?? ["avif", "webp", "original"];
+  const quality = { webp: 80, avif: 60, jpeg: 85, ...options.quality };
+  const lqipStrategy = options.lqip ?? "inline";
+  const avifEffort = options.avifEffort ?? 4;
+
+  let isBuild = false;
+  let root = process.cwd();
+
+  // Dev: serve processed buffers from this map at MIDDLEWARE_PREFIX
+  // Key: middleware URL path; Value: { bytes, mime }
+  const devAssets = new Map<string, { bytes: Uint8Array; mime: string }>();
+
+  return {
+    name: "image-optimizer",
+    enforce: "pre",
+
+    configResolved(config) {
+      root = config.root;
+      isBuild = config.command === "build";
+      setCacheDir(join(config.cacheDir, ".image-optimizer"));
+    },
+
+    resolveId(id) {
+      // Claim any `*.{jpg,jpeg,png,webp}?responsive` id so other plugins skip it.
+      if (hasResponsiveQuery(id) && isImageExt(idWithoutQuery(id))) {
+        return id;
+      }
+      return null;
+    },
+
+    async load(id) {
+      if (!hasResponsiveQuery(id)) return null;
+      const filePath = idWithoutQuery(id);
+      if (!isImageExt(filePath)) return null;
+
+      const absPath = resolve(root, filePath.startsWith("/") ? filePath.slice(1) : filePath);
+      const sourceBytes = new Uint8Array(readFileSync(absPath));
+
+      const ext = filePath.split(".").pop()!.toLowerCase();
+      const originalFormat: "jpeg" | "png" = ext === "png" ? "png" : "jpeg";
+
+      // Resolve concrete output format list
+      const resolvedFormats = formats.map((f) =>
+        f === "original" ? originalFormat : (f as "webp" | "avif"),
+      );
+      // Dedupe and sort in browser-preference order
+      const uniqueFormats = sortFormats(
+        Array.from(new Set(resolvedFormats)) as Array<"jpeg" | "png" | "webp" | "avif">,
+      );
+
+      // Metadata for aspectRatio + LQIP svg viewBox
+      const meta = await getMetadata(sourceBytes);
+
+      // Process every (width × format) combo
+      const variants: Array<{
+        width: number;
+        format: string;
+        refId?: string;
+        devUrl?: string;
+      }> = [];
+
+      for (const format of uniqueFormats) {
+        for (const width of widths) {
+          if (width > meta.width) continue; // never upscale
+
+          const qualityForFormat = quality[format as keyof typeof quality] ?? 85;
+          const cacheParams = `${width}|${format}|${qualityForFormat}|${format === "avif" ? avifEffort : 0}`;
+          const key = cacheKey(sourceBytes, cacheParams);
+          const outExt = format === "jpeg" ? "jpg" : format;
+
+          let bytes = readCache(key, outExt);
+          if (!bytes) {
+            bytes = await resizeAndEncode(
+              sourceBytes,
+              width,
+              format as "webp" | "avif" | "jpeg" | "png",
+              qualityForFormat,
+              avifEffort,
+            );
+            writeCache(key, outExt, bytes);
+          }
+
+          const baseName = filePath
+            .split(/[\\/]/)
+            .pop()!
+            .replace(/\.[^.]+$/, "");
+          const assetName = `${baseName}-${width}w.${outExt}`;
+
+          if (isBuild) {
+            const refId = this.emitFile({ type: "asset", name: assetName, source: bytes });
+            variants.push({ width, format, refId });
+          } else {
+            const devUrl = `${MIDDLEWARE_PREFIX}${key}/${assetName}`;
+            devAssets.set(devUrl, { bytes, mime: `image/${format}` });
+            variants.push({ width, format, devUrl });
+          }
+        }
+      }
+
+      // LQIP
+      let lqipDataUri = "";
+      if (lqipStrategy === "inline") {
+        lqipDataUri = await generateInlineLqip(sourceBytes, meta.width, meta.height);
+      }
+
+      // Build variants JS — use ROLLUP_FILE_URL marker in build, dev URL string in dev
+      const variantsJs = variants
+        .map((v) => {
+          const urlExpr = isBuild
+            ? `import.meta.ROLLUP_FILE_URL_${v.refId}`
+            : JSON.stringify(v.devUrl);
+          return `{ width: ${v.width}, format: ${JSON.stringify(v.format)}, url: ${urlExpr} }`;
+        })
+        .join(",\n  ");
+
+      const imageTypesJs = JSON.stringify(uniqueFormats.map((f) => (f === "jpeg" ? "jpeg" : f)));
+      const widthsActuallyUsed = Array.from(new Set(variants.map((v) => v.width))).sort(
+        (a, b) => a - b,
+      );
+
+      const lqipSection = lqipDataUri
+        ? `  lqip: { inlineStyles: { "background-image": \`url("${lqipDataUri}")\`, "background-size": "cover" } },`
+        : "";
+
+      return `
+const variants = [
+  ${variantsJs}
+];
+const findMatch = (width, type) => {
+  const candidates = variants.filter(v => !type || v.format === type);
+  const sorted = candidates.sort((a, b) => a.width - b.width);
+  return (sorted.find(v => v.width >= width) ?? sorted[sorted.length - 1])?.url;
+};
+export default {
+  imageTypes: ${imageTypesJs},
+  availableWidths: ${JSON.stringify(widthsActuallyUsed)},
+  aspectRatio: ${meta.aspectRatio},
+  imageUrlFor: findMatch,
+${lqipSection}
+};
+`;
+    },
+
+    configureServer(server) {
+      server.middlewares.use(MIDDLEWARE_PREFIX, (req, res, next) => {
+        const url = req.url ?? "";
+        const fullPath = MIDDLEWARE_PREFIX + url.replace(/^\//, "").split("?")[0];
+        const asset = devAssets.get(fullPath);
+        if (!asset) {
+          next();
+          return;
+        }
+        res.setHeader("Content-Type", asset.mime);
+        res.setHeader("Cache-Control", "no-cache");
+        res.end(Buffer.from(asset.bytes));
+      });
+    },
+  };
+}

--- a/lib/image-optimizer/process.ts
+++ b/lib/image-optimizer/process.ts
@@ -1,0 +1,78 @@
+import Vips from "wasm-vips";
+
+type VipsModule = Awaited<ReturnType<typeof Vips>>;
+// Image instances returned by the wasm-vips API
+type VipsImage = ReturnType<VipsModule["Image"]["newFromBuffer"]>;
+
+let vipsInstance: VipsModule | null = null;
+let initPromise: Promise<VipsModule> | null = null;
+
+export async function initVips(): Promise<VipsModule> {
+  if (vipsInstance) return vipsInstance;
+  if (initPromise) return initPromise;
+
+  initPromise = Vips({ dynamicLibraries: ["vips-heif.wasm"] }).then((v) => {
+    vipsInstance = v;
+    return v;
+  });
+
+  return initPromise;
+}
+
+export async function getMetadata(
+  bytes: Uint8Array,
+): Promise<{ width: number; height: number; aspectRatio: number }> {
+  const vips = await initVips();
+  const img: VipsImage = vips.Image.newFromBuffer(bytes);
+  try {
+    const width = img.width;
+    const height = img.height;
+    return { width, height, aspectRatio: width / height };
+  } finally {
+    img.delete();
+  }
+}
+
+export async function resizeAndEncode(
+  bytes: Uint8Array,
+  width: number,
+  format: "webp" | "avif" | "jpeg" | "png",
+  quality: number,
+  avifEffort: number,
+): Promise<Uint8Array> {
+  const vips = await initVips();
+  const img: VipsImage = vips.Image.newFromBuffer(bytes);
+  const oriented: VipsImage = img.autorot();
+  const resized: VipsImage = oriented.thumbnailImage(width);
+
+  try {
+    return encodeImage(vips, resized, format, quality, avifEffort);
+  } finally {
+    img.delete();
+    oriented.delete();
+    resized.delete();
+  }
+}
+
+function encodeImage(
+  vips: VipsModule,
+  img: VipsImage,
+  format: "webp" | "avif" | "jpeg" | "png",
+  quality: number,
+  avifEffort: number,
+): Uint8Array {
+  switch (format) {
+    case "webp":
+      return img.writeToBuffer(".webp", { Q: quality });
+    case "avif":
+      return img.writeToBuffer(".avif", {
+        Q: quality,
+        compression: vips.ForeignHeifCompression.av1,
+        effort: avifEffort,
+      });
+    case "jpeg":
+      return img.writeToBuffer(".jpg", { Q: quality });
+    case "png":
+      return img.writeToBuffer(".png");
+  }
+}

--- a/lib/image-optimizer/types.ts
+++ b/lib/image-optimizer/types.ts
@@ -1,0 +1,29 @@
+export type ImageType = "png" | "jpeg" | "webp" | "avif";
+export type ImageTypeAuto = "auto";
+
+export interface Lqip {
+  class?: string | (() => string);
+  attribute?: string;
+  inlineStyles?: Record<string, string> | (() => Record<string, string>);
+}
+
+export interface ImageData {
+  imageTypes: ImageType[] | ImageTypeAuto;
+  availableWidths?: number[];
+  aspectRatio?: number;
+  imageUrlFor(width: number, type?: ImageType): string | undefined;
+  lqip?: Lqip;
+}
+
+export interface ImageOptimizerOptions {
+  /** Output widths in pixels. Default: [640, 750, 828, 1080, 1200, 1920, 2048, 3840] */
+  widths?: number[];
+  /** Output formats. `original` preserves input format (jpeg/png). Default: ['avif', 'webp', 'original'] */
+  formats?: Array<"avif" | "webp" | "original">;
+  /** Per-format quality 1–100. Defaults: webp 80, avif 60, jpeg 85 */
+  quality?: { webp?: number; avif?: number; jpeg?: number };
+  /** LQIP strategy. `inline` = blurred SVG data URI. `false` = none. Default: 'inline' */
+  lqip?: "inline" | false;
+  /** AVIF encoder effort 0–9. Higher = smaller + slower. Default: 4 */
+  avifEffort?: number;
+}

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "ttf2woff2": "^8.0.1",
     "tunnel-rat": "^0.1.2",
     "valibot": "^1.3.1",
+    "wasm-vips": "^0.0.17",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.28.5",
     "@react-router/dev": "^7.14.0",
-    "@responsive-image/vite-plugin": "^3.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,11 @@
 import { reactRouter } from "@react-router/dev/vite";
-import { responsiveImage } from "@responsive-image/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import browserslist from "browserslist";
 import { browserslistToTargets, composeVisitors } from "lightningcss";
 import { defineConfig } from "vite";
 import babel from "vite-plugin-babel";
 import svgr from "vite-plugin-svgr";
+import { imageOptimizer } from "./lib/image-optimizer/index.ts";
 import { fontOptimizer } from "./lib/font-optimizer/index.ts";
 import { fonts } from "./styles/fonts.ts";
 import { darkroomStyling } from "./styles/scripts/vite/darkroom-styling.ts";
@@ -28,10 +28,7 @@ export default defineConfig({
       },
     }),
     svgr(),
-    responsiveImage({
-      w: [768, 1600],
-      format: ["webp", "avif"],
-    }),
+    imageOptimizer(),
     darkroomStyling(),
   ],
   envPrefix: "PUBLIC_",


### PR DESCRIPTION
## Summary

Replaces `@responsive-image/vite-plugin` with a custom `lib/image-optimizer/` built on **wasm-vips** (libvips compiled to WebAssembly). Zero native deps, sibling to the existing `lib/font-optimizer/`. Same WASM-direct ethos as the font tooling — no node-gyp, no per-arch prebuild matrix.

## What it does

- `imageOptimizer()` Vite plugin intercepts `?responsive` query imports (e.g. `import hero from "./hero.jpg?responsive"`)
- Per-image: resize to configured widths × `{avif, webp, original}`, input-format preserving (jpeg/png)
- Inline-SVG LQIP via `feGaussianBlur` over a 16px PNG (~1KB data URI, zero runtime JS)
- Content-addressed disk cache under `config.cacheDir/.image-optimizer/`
- Dev: `configureServer` middleware serves variants from memory; build: `this.emitFile()` + `import.meta.ROLLUP_FILE_URL` markers

## Structural note

Unlike font-optimizer (pre-enumeration via `defineFont()` in vite config), image-optimizer uses **per-file `?responsive` interception** — images are referenced at use sites and can't be enumerated upfront. No registry, no runtime-state bridge, no virtual modules. 7 source files vs font-optimizer's 11.

## Phase 1 boundary

The emitted `ImageData` matches `@responsive-image/core`'s shape byte-for-byte, so `components/image.tsx` is **unchanged** — it keeps using `<ResponsiveImage>` from `@responsive-image/react`. Only `@responsive-image/vite-plugin` was removed. Phase 2 (future): write our own `<ResponsiveImage>` and drop the last two `@responsive-image/*` deps.

## Dropped by design

blurhash, thumbhash, dominant-color LQIP, art direction, per-import query overrides, remote/Sanity URL handling, HEIF/TIFF/GIF output.

## Test Plan

- [x] `bun run check` — lint + format + typecheck clean
- [x] `bun run build` — clean (plugin loads; no `?responsive` imports exist yet so the transform path doesn't fire)
- [x] wasm-vips smoke test on a synthetic 1024×768 JPEG: WebP 844B / AVIF 757B / JPEG 5601B / LQIP SVG 938B — all formats encode correctly, `vips-heif.wasm` loads for AVIF
- [ ] **Not yet exercised in CI**: no real `?responsive` import in the tree. First consumer (likely an `example/` hero) will validate the full transform path end-to-end.