### PR TITLE
refactor(orchestra): make @novus/orchestra a self-contained package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,12 +97,17 @@
         "hamo": "1.0.0-dev.13",
         "stats-gl": "^4.1.0",
         "tempus": "1.0.0-dev.17",
-        "three": "^0.183.2",
         "zustand": "^5.0.12",
       },
       "peerDependencies": {
+        "@react-three/fiber": ">=9",
         "react": ">=19",
+        "three": ">=0.180",
       },
+      "optionalPeers": [
+        "@react-three/fiber",
+        "three",
+      ],
     },
     "packages/password-protection": {
       "name": "@novus/password-protection",

--- a/bun.lock
+++ b/bun.lock
@@ -90,10 +90,8 @@
       "name": "@novus/orchestra",
       "version": "0.1.0",
       "dependencies": {
-        "@base-ui/react": "^1.3.0",
         "@theatre/core": "^0.7.2",
         "@theatre/studio": "^0.7.2",
-        "clsx": "^2.1.1",
         "hamo": "1.0.0-dev.13",
         "stats-gl": "^4.1.0",
         "tempus": "1.0.0-dev.17",
@@ -102,6 +100,7 @@
       "peerDependencies": {
         "@react-three/fiber": ">=9",
         "react": ">=19",
+        "react-dom": ">=19",
         "three": ">=0.180",
       },
       "optionalPeers": [
@@ -387,10 +386,6 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
-
-    "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -2239,8 +2234,6 @@
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
-
-    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 

--- a/packages/orchestra/README.md
+++ b/packages/orchestra/README.md
@@ -1,0 +1,41 @@
+# @novus/orchestra
+
+The starter's in-app dev debug panel. A keyboard-summoned command palette (`Ctrl/⌘+.` or `Ctrl+O`) that toggles a set of overlays — layout grid, scroll minimap, GPU stats, and a Theatre.js studio — plus the Theatre.js sheet/animation runtime those overlays drive.
+
+Renders `null` in production (`process.env.NODE_ENV !== "development"`), so it's safe to mount unconditionally.
+
+## Usage
+
+Mount once, near the root, lazily:
+
+```tsx
+import { lazy } from "react";
+const OrchestraTools = lazy(() => import("@novus/orchestra"));
+
+// in dev only
+{
+  process.env.NODE_ENV === "development" && <OrchestraTools />;
+}
+```
+
+## Exports
+
+| Entry                         | Provides                                                                                                                                              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.`                           | `OrchestraTools` (default — the panel) and `useOrchestra()` (read toggle state)                                                                       |
+| `./theatre`                   | Theatre.js runtime: `TheatreProjectProvider`, `SheetProvider`, `SheetContext`, `useSheet`, `useCurrentSheet`, `useSheetDuration`, `useCurrentProject` |
+| `./theatre/hooks/use-theatre` | `useTheatre` / `useTheatreObject` — bind a Theatre sheet object to React                                                                              |
+
+The Theatre runtime is consumed at app **runtime** (e.g. the WebGL layer drives meshes off sheets), not just in dev — only the studio editor is dev-gated.
+
+## Peer dependencies
+
+- **`react` >= 19** (required).
+- **`three` >= 0.180** and **`@react-three/fiber` >= 9** (optional) — only needed for the internal Theatre-controlled R3F `Group` helper (`./theatre/r3f`); the panel and the rest of the Theatre runtime don't touch them.
+
+## Soft expectations of the host app
+
+These are debug-tool conveniences, not hard requirements — the package won't crash without them, but the overlays look right only when the host provides:
+
+- **Tailwind v4** with the starter's `primary` / `secondary` color tokens — the command palette UI is styled with utility classes.
+- **`--columns` CSS variable** and a grid utility class (defaults to `dr-layout-grid`, overridable via `GridDebugger`'s `gridClassName` prop) — the grid overlay reads the active column count from `--columns`.

--- a/packages/orchestra/README.md
+++ b/packages/orchestra/README.md
@@ -28,14 +28,17 @@ const OrchestraTools = lazy(() => import("@novus/orchestra"));
 
 The Theatre runtime is consumed at app **runtime** (e.g. the WebGL layer drives meshes off sheets), not just in dev — only the studio editor is dev-gated.
 
+### `window.THEATRE_PROJECT_ID`
+
+Importing the Theatre runtime augments `Window` with a typed `THEATRE_PROJECT_ID?: string`. It's set at runtime once a Theatre project loads, so anywhere in the app can read the active project id off `window.THEATRE_PROJECT_ID` without re-declaring the global.
+
 ## Peer dependencies
 
-- **`react` >= 19** (required).
-- **`three` >= 0.180** and **`@react-three/fiber` >= 9** (optional) — only needed for the internal Theatre-controlled R3F `Group` helper (`./theatre/r3f`); the panel and the rest of the Theatre runtime don't touch them.
+- **`react` >= 19** and **`react-dom` >= 19** (required) — the panel renders through `createPortal`.
+- **`three` >= 0.180** and **`@react-three/fiber` >= 9** (optional) — only needed for the Theatre-controlled R3F `Group` helper (`./theatre/r3f`); the panel and the rest of the Theatre runtime don't touch them.
 
-## Soft expectations of the host app
+The panel ships its own styles (CSS Modules — no Tailwind) and has no UI-primitive dependency, so it drops into any React app.
 
-These are debug-tool conveniences, not hard requirements — the package won't crash without them, but the overlays look right only when the host provides:
+## Grid overlay
 
-- **Tailwind v4** with the starter's `primary` / `secondary` color tokens — the command palette UI is styled with utility classes.
-- **`--columns` CSS variable** and a grid utility class (defaults to `dr-layout-grid`, overridable via `GridDebugger`'s `gridClassName` prop) — the grid overlay reads the active column count from `--columns`.
+`GridDebugger` reads the active column count from a `--columns` CSS variable and paints over a grid class (defaults to `dr-layout-grid`, overridable via the `gridClassName` prop). If the host app doesn't define `--columns`, the overlay simply renders no columns — everything else works without it.

--- a/packages/orchestra/cmdo.module.css
+++ b/packages/orchestra/cmdo.module.css
@@ -1,0 +1,28 @@
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgb(0 0 0 / 0.2);
+  backdrop-filter: blur(2px);
+  cursor: pointer;
+}
+
+.popup {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  transform: translate(-50%, -50%);
+  border-radius: 12px;
+  outline: 1px solid #e5e5e5;
+  background: #fff;
+  color: #111;
+}

--- a/packages/orchestra/cmdo.tsx
+++ b/packages/orchestra/cmdo.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import s from "./cmdo.module.css";
 import Orchestra from "./orchestra";
 import { OrchestraToggle } from "./toggle";
 
@@ -36,26 +37,28 @@ export function Cmdo() {
     return () => document.removeEventListener("keydown", down);
   }, []);
 
-  return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Portal keepMounted>
-        <div id="orchestra">
-          <Dialog.Backdrop className="fixed inset-0 z-40 bg-secondary/20 backdrop-blur-[2px] transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-          <Dialog.Popup className="-translate-1/2 fixed top-1/2 left-1/2 z-99999 rounded-[12px] rounded-lg bg-primary text-gray-900 outline outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[starting-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
-            <div className="flex gap-4 gap-[4px] rounded-lg p-[4px] [&_button]:grid [&_button]:size-full [&_button]:place-items-center">
-              <OrchestraToggle id="grid">🌐</OrchestraToggle>
-              <OrchestraToggle id="studio">⚙️</OrchestraToggle>
-              <OrchestraToggle id="stats">📈</OrchestraToggle>
-              <OrchestraToggle id="dev">🚧</OrchestraToggle>
-              <OrchestraToggle id="minimap">🗺️</OrchestraToggle>
-              <OrchestraToggle id="webgl" defaultValue={true}>
-                🧊
-              </OrchestraToggle>
-              <OrchestraToggle id="screenshot">📸</OrchestraToggle>
-            </div>
-          </Dialog.Popup>
-        </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+  if (!open) return null;
+
+  return createPortal(
+    <div id="orchestra" className={s.root}>
+      <button
+        type="button"
+        aria-label="Close debug panel"
+        className={s.backdrop}
+        onClick={() => setOpen(false)}
+      />
+      <div className={s.popup}>
+        <OrchestraToggle id="grid">🌐</OrchestraToggle>
+        <OrchestraToggle id="studio">⚙️</OrchestraToggle>
+        <OrchestraToggle id="stats">📈</OrchestraToggle>
+        <OrchestraToggle id="dev">🚧</OrchestraToggle>
+        <OrchestraToggle id="minimap">🗺️</OrchestraToggle>
+        <OrchestraToggle id="webgl" defaultValue={true}>
+          🧊
+        </OrchestraToggle>
+        <OrchestraToggle id="screenshot">📸</OrchestraToggle>
+      </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/orchestra/grid/grid.module.css
+++ b/packages/orchestra/grid/grid.module.css
@@ -1,4 +1,13 @@
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  pointer-events: none;
+}
+
 .debugger {
+  position: absolute;
+  inset: 0;
   background-image: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 50%, rgba(247, 181, 68, 0.1) 50%);
   background-size: var(--gap) var(--gap);
 

--- a/packages/orchestra/grid/index.tsx
+++ b/packages/orchestra/grid/index.tsx
@@ -1,4 +1,3 @@
-import cn from "clsx";
 import { useWindowSize } from "hamo";
 import { useMemo } from "react";
 import s from "./grid.module.css";
@@ -17,8 +16,8 @@ export default function GridDebugger({ gridClassName = "dr-layout-grid" }: GridD
   );
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-10000">
-      <div className={cn(gridClassName, "absolute inset-0", s.debugger)}>
+    <div className={s.root}>
+      <div className={gridClassName ? `${gridClassName} ${s.debugger}` : s.debugger}>
         {Array.from({ length: columns }).map((_, index) => (
           <span key={`column-${index}`} />
         ))}

--- a/packages/orchestra/package.json
+++ b/packages/orchestra/package.json
@@ -9,10 +9,8 @@
     "./theatre/hooks/use-theatre": "./theatre/hooks/use-theatre.ts"
   },
   "dependencies": {
-    "@base-ui/react": "^1.3.0",
     "@theatre/core": "^0.7.2",
     "@theatre/studio": "^0.7.2",
-    "clsx": "^2.1.1",
     "hamo": "1.0.0-dev.13",
     "stats-gl": "^4.1.0",
     "tempus": "1.0.0-dev.17",
@@ -21,6 +19,7 @@
   "peerDependencies": {
     "@react-three/fiber": ">=9",
     "react": ">=19",
+    "react-dom": ">=19",
     "three": ">=0.180"
   },
   "peerDependenciesMeta": {

--- a/packages/orchestra/package.json
+++ b/packages/orchestra/package.json
@@ -16,10 +16,19 @@
     "hamo": "1.0.0-dev.13",
     "stats-gl": "^4.1.0",
     "tempus": "1.0.0-dev.17",
-    "three": "^0.183.2",
     "zustand": "^5.0.12"
   },
   "peerDependencies": {
-    "react": ">=19"
+    "@react-three/fiber": ">=9",
+    "react": ">=19",
+    "three": ">=0.180"
+  },
+  "peerDependenciesMeta": {
+    "@react-three/fiber": {
+      "optional": true
+    },
+    "three": {
+      "optional": true
+    }
   }
 }

--- a/packages/orchestra/theatre/index.tsx
+++ b/packages/orchestra/theatre/index.tsx
@@ -17,6 +17,13 @@ import {
   useState,
 } from "react";
 
+declare global {
+  interface Window {
+    /** Active Theatre.js project id, set once a project loads. */
+    THEATRE_PROJECT_ID?: string;
+  }
+}
+
 const TheatreProjectContext = createContext<IProject | undefined>(undefined);
 
 type TheatreProjectProviderProps = {
@@ -35,9 +42,7 @@ export function TheatreProjectProvider({
   useEffect(() => {
     if (project) {
       isLoadingRef.current = false;
-      // Cast rather than rely on a global ambient declaration so the package
-      // stays self-contained (matches the read in ./studio).
-      (window as { THEATRE_PROJECT_ID?: string }).THEATRE_PROJECT_ID = project.address.projectId;
+      window.THEATRE_PROJECT_ID = project.address.projectId;
       console.log(`Theatre: project ${id} loaded`);
     }
   }, [project, id]);

--- a/packages/orchestra/theatre/index.tsx
+++ b/packages/orchestra/theatre/index.tsx
@@ -35,7 +35,9 @@ export function TheatreProjectProvider({
   useEffect(() => {
     if (project) {
       isLoadingRef.current = false;
-      window.THEATRE_PROJECT_ID = project.address.projectId;
+      // Cast rather than rely on a global ambient declaration so the package
+      // stays self-contained (matches the read in ./studio).
+      (window as { THEATRE_PROJECT_ID?: string }).THEATRE_PROJECT_ID = project.address.projectId;
       console.log(`Theatre: project ${id} loaded`);
     }
   }, [project, id]);

--- a/packages/orchestra/theatre/studio/index.tsx
+++ b/packages/orchestra/theatre/studio/index.tsx
@@ -5,7 +5,7 @@ import s from "./studio.module.css";
 type StudioInstance = any;
 
 function getProjectId(): string | undefined {
-  return (window as { THEATRE_PROJECT_ID?: string }).THEATRE_PROJECT_ID;
+  return window.THEATRE_PROJECT_ID;
 }
 
 function downloadState(studio: StudioInstance, projectId: string) {

--- a/packages/orchestra/toggle.module.css
+++ b/packages/orchestra/toggle.module.css
@@ -1,0 +1,15 @@
+.toggle {
+  display: grid;
+  place-items: center;
+  width: 80px;
+  height: 80px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 64px;
+  cursor: pointer;
+}
+
+.active {
+  background: rgb(0 255 0 / 0.5);
+}

--- a/packages/orchestra/toggle.tsx
+++ b/packages/orchestra/toggle.tsx
@@ -1,5 +1,6 @@
 import { type HTMLAttributes, type RefObject, useEffect, useState } from "react";
 import Orchestra from "./orchestra";
+import s from "./toggle.module.css";
 
 type OrchestraToggleProps = Omit<
   HTMLAttributes<HTMLButtonElement>,
@@ -45,10 +46,7 @@ export function OrchestraToggle({
       onClick={() => {
         Orchestra.setState((state) => ({ [id]: !state[id] }));
       }}
-      style={{
-        backgroundColor: active ? "rgba(0, 255, 0, 0.5)" : "",
-      }}
-      className="grid size-20 place-items-center rounded-[8px] text-[64px]"
+      className={active ? `${s.toggle} ${s.active}` : s.toggle}
       title={id}
     >
       {children}

--- a/utils/types.d.ts
+++ b/utils/types.d.ts
@@ -8,10 +8,6 @@ declare module "react" {
 }
 
 declare global {
-  interface Window {
-    THEATRE_PROJECT_ID?: string;
-  }
-
   /**
    * Build-time constant injected by `vite.config.ts` via `define`. Used by
    * `components/dev-only` to drop dev-only modules from production bundles


### PR DESCRIPTION
## Summary

Hardens `@novus/orchestra` (the dev debug panel) into a package that drops into any React app — no Tailwind, no UI-primitive dependency, no app-owned globals. Two commits:

**1. Dependency correctness + decoupling**
- `three` → optional `peerDependency` (only a type import in the unexported R3F `Group` helper); added `@react-three/fiber` as an optional peer for the `<group>` it renders.

**2. Self-contained panel**
- **Base UI removed** — `Cmdo` renders via `createPortal` + the existing keydown handler instead of `@base-ui/react` `Dialog`. (`react-dom` added as a peer.)
- **Tailwind removed** — the command palette, toggles, and grid overlay are styled with CSS Modules (token-free neutral colors) instead of `bg-primary`/`secondary` utility classes.
- **clsx removed** — classNames composed with template strings.
- **Owns its global** — `theatre/index` declares and writes the typed `window.THEATRE_PROJECT_ID` itself (and `studio` reads it directly), so the app's `utils/types.d.ts` no longer needs to declare it. Importing the Theatre runtime makes the global readable + typed anywhere.
- Added a `README` documenting exports, peers, and the remaining soft host expectation (the grid overlay reads `--columns` / `--gap`, already overridable).

### Dependency tally
- **Runtime:** `@theatre/core`, `@theatre/studio`, `hamo`, `stats-gl`, `tempus`, `zustand`
- **Required peers:** `react`, `react-dom`
- **Optional peers:** `three`, `@react-three/fiber`
- **Removed:** `@base-ui/react`, `clsx`, `three` (→ optional peer)

## Test Plan
- [x] `bun install` — `@base-ui/react` + `clsx` out of the lockfile; peers resolve
- [x] `bun run check` — lint 0/0, format, typecheck clean
- [x] `bun run build` — green