### PR TITLE
fix: claim novus package identity, rewrite cursor rules for the real stack

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -1,233 +1,57 @@
 # Cursor Rules Documentation
 
-This directory contains consolidated Cursor AI rules for the Satus project. The rules are organized into 5 focused files for easy maintenance and efficient AI context loading.
+This directory contains Cursor AI rules for the **Novus** project (React
+Router 7 starter by darkroom.engineering), organized into 5 focused files.
 
-## 📁 File Structure
+## File Structure
 
-### 1. `main.mdc` - Project Overview & Cross-Cutting Concerns
+### 1. `main.mdc` — Project Overview & Cross-Cutting Concerns
 
-**Purpose**: High-level overview and concerns that apply across the entire project
+Technology stack (React Router 7, React 19, TypeScript, Tailwind v4, Bun),
+path alias (`~/`), file organization, critical rules (Wrapper, image/link
+components, no manual memoization, `import type`, env pattern).
 
-**Contents**:
+### 2. `architecture.mdc` — Architecture Patterns & Best Practices
 
-- Technology stack (Next.js 16+, React 19+, Tailwind v4, Biome, Bun)
-- React 19+ new features (`<Activity />`, `useEffectEvent`, `cacheSignal`)
-- Next.js 16 Cache Components gotchas and best practices
-- File organization
-- React Compiler & memoization guidelines (single source of truth)
-- Image optimization guidelines (single source of truth)
-- Development vs production guidelines (single source of truth)
-- Core utility libraries (`@/utils`)
+Type safety, state management (React state, Zustand), routing & data loading
+(React Router loaders), root layout pattern (`app/root.tsx`), workspace
+packages (`packages/*`), security (env validation), code quality, dev workflow.
 
-**When to reference**: Starting a new project, understanding the tech stack, cross-cutting concerns
+### 3. `components.mdc` — React Component Patterns & WebGL
 
----
+Component structure, CSS Modules, props interfaces, lazy loading, the list of
+reusable `components/`, and the WebGL system (`webgl/`: Canvas, Tunnel, R3F,
+Drei, post-processing).
 
-### 2. `components.mdc` - React Component Patterns & WebGL
+### 4. `styling.mdc` — CSS Modules, Tailwind CSS v4 & Custom Utilities
 
-**Purpose**: All React component patterns including standard components and WebGL/Three.js
+CSS Modules conventions, design tokens (`styles/*.ts`), Lightning CSS custom
+functions (`mobile-vw()`, `desktop-vw()`, `columns()`), Tailwind v4 basics, and
+the generated `dr-*` utility classes from `@novus/styling`.
 
-**Contents**:
+### 5. `integrations.mdc` — Third-Party Integrations
 
-- Component structure and imports
-- Props interfaces and React 19 ref handling
-- Forms and responsive design
-- Performance best practices (code splitting)
-- Error handling
-- WebGL/Three.js setup and patterns
-- React Three Fiber
-- Drei components
-- Custom shaders
-- Animation and interaction
-- Post-processing
+Sanity CMS only: client setup, env vars (`PUBLIC_SANITY_*`), GROQ queries,
+data fetching via loaders, images, SEO, schema conventions. Also notes the
+opt-in `lib/` and `packages/*` modules (password-protection, static-i18n,
+transitions).
 
-**When to reference**: Building React components, creating WebGL experiences, working with Three.js
+## Quick Reference
 
----
+- **Start a new feature** → `main.mdc`, then `architecture.mdc`
+- **Build a component** → `components.mdc`
+- **Add WebGL/Three.js** → `components.mdc` § WebGL Components
+- **Style a component** → `styling.mdc`
+- **Fetch Sanity content** → `integrations.mdc`
+- **State management / routing** → `architecture.mdc`
 
-### 3. `styling.mdc` - CSS Modules & Tailwind CSS v4
+## Maintenance
 
-**Purpose**: All styling approaches including CSS Modules and Tailwind CSS v4
+- Keep claims verified against the actual codebase, not assumed from other
+  darkroom.engineering starters (e.g. `satus`, which is built on a different
+  meta-framework — its rules do not apply here).
+- Update the "Last updated" date at the bottom of a file when editing it.
+- If `packages/*` workspace extraction moves more `lib/` modules, update
+  `architecture.mdc` § Workspace Packages and `integrations.mdc` accordingly.
 
-**Contents**:
-
-- CSS Modules (file naming, class naming, imports)
-- Responsive design (viewport functions, breakpoints, grid system)
-- Typography and colors
-- Animations and transitions
-- Tailwind CSS v4 (CSS-first configuration, theme variables, new features)
-- 3D transforms, gradients, shadows
-- New variants (composable, `starting`, `not-*`, `nth-*`)
-- Custom extensions (`@utility`, `@variant`, `@plugin`)
-- Breaking changes and migration
-- Project-specific custom utilities (`dr-*` classes)
-- PostCSS functions
-
-**When to reference**: Styling components, using Tailwind, creating responsive designs
-
----
-
-### 4. `integrations.mdc` - Third-Party Integrations
-
-**Purpose**: Guidelines for all third-party service integrations
-
-**Contents**:
-
-- **Sanity CMS**: Configuration, schema management, GROQ queries, visual editing, TypeScript generation, cacheSignal integration
-- **Shopify**: API configuration, product management, cart operations, cacheSignal integration
-- **HubSpot**: Form integration, newsletter subscriptions
-- General best practices (environment variables, API resilience, error handling)
-- Cache Components gotchas for integrations (user-specific data, real-time data)
-- Type safety and performance
-- Security and integration management
-- Webhook handling
-
-**When to reference**: Integrating with Sanity, Shopify, HubSpot, or other third-party services
-
----
-
-### 5. `architecture.mdc` - Architecture Patterns & Best Practices
-
-**Purpose**: Architectural patterns, state management, routing, and code quality guidelines
-
-**Contents**:
-
-- Type safety (TypeScript configuration)
-- State management (React state, Zustand)
-- Routing & navigation (Next.js App Router, Link component)
-- Metadata & SEO
-- Performance (server components, code splitting, caching)
-- Cache Components (Next.js 16) - Suspense, invalidation, gotchas
-- Security (environment variables, input validation, authentication)
-- Testing & debugging (unit tests, debugging tools, error boundaries)
-- Code quality (linting, formatting, code organization)
-- Development workflow (package manager, git workflow, client/server boundaries)
-
-**When to reference**: Architectural decisions, state management, routing patterns, code quality
-
----
-
-## 🎯 Quick Reference Guide
-
-### I want to...
-
-- **Start a new feature** → Read `main.mdc` for overview, then `architecture.mdc` for patterns
-- **Build a React component** → `components.mdc`
-- **Add WebGL/Three.js** → `components.mdc` § WebGL Components & Activity Integration
-- **Style with CSS Modules** → `styling.mdc` § CSS Modules
-- **Style with Tailwind** → `styling.mdc` § Tailwind CSS v4
-- **Use custom utilities** → `styling.mdc` § Project-Specific Custom Utilities
-- **Integrate Sanity CMS** → `integrations.mdc` § Sanity CMS Integration
-- **Integrate Shopify** → `integrations.mdc` § Shopify Integration
-- **Integrate HubSpot** → `integrations.mdc` § HubSpot Forms
-- **Manage state** → `architecture.mdc` § State Management
-- **Add routing** → `architecture.mdc` § Routing & Navigation
-- **Optimize performance** → `architecture.mdc` § Performance
-- **Handle security** → `architecture.mdc` § Security
-- **Debug issues** → `architecture.mdc` § Testing & Debugging
-- **Understand React Compiler** → `main.mdc` § React Compiler & Memoization
-- **Handle images** → `main.mdc` § Image Optimization (`@/components/ui/image`)
-- **Dev vs prod differences** → `main.mdc` § Development vs Production
-- **Use utility functions** → `main.mdc` § Core Utility Libraries (`@/utils`)
-
----
-
-## 🔄 Migration from Old Structure
-
-### What Changed?
-
-**Before (7 files)**:
-
-1. `main.mdc` - Overview
-2. `components.mdc` - React components
-3. `webgl.mdc` - WebGL/Three.js
-4. `styling.mdc` - CSS Modules
-5. `tailwind-css-v4.mdc` - Tailwind
-6. `integrations.mdc` - General integrations
-7. `sanity-opinionated.mdc` - Sanity-specific
-
-**After (5 files)**:
-
-1. `main.mdc` - Overview + cross-cutting concerns
-2. `components.mdc` - React + WebGL (merged)
-3. `styling.mdc` - CSS Modules + Tailwind (merged)
-4. `integrations.mdc` - All third-party integrations (merged Sanity)
-5. `architecture.mdc` - NEW: Architecture patterns
-
-### Benefits of Consolidation
-
-✅ **Reduced duplication**: React Compiler, Image optimization, Dev/Prod guidelines now in ONE place
-✅ **Easier to find**: Related content is together (e.g., all styling in one file)
-✅ **Better context for AI**: Fewer files means more efficient context loading
-✅ **Easier maintenance**: Less jumping between files, clearer organization
-✅ **Clearer separation**: Each file has a distinct purpose
-
----
-
-## 📝 Maintenance Guidelines
-
-### When Editing Rules
-
-1. **Avoid Duplication**: If content applies to multiple areas, put it in `main.mdc` and reference it
-2. **Use Cross-References**: Link to other sections instead of duplicating content
-3. **Keep It Focused**: Each file should maintain its specific purpose
-4. **Update Dates**: Update the "Last updated" date when making changes
-5. **Check Dependencies**: When updating one file, check if related files need updates
-
-### Example Cross-Reference Pattern
-
-```markdown
-<!-- In components.mdc -->
-
-## Performance Optimization
-
-See main.mdc § React Compiler & Memoization for optimization guidelines.
-```
-
-### Adding New Content
-
-**Ask yourself**:
-
-- Is this component-specific? → `components.mdc`
-- Is this styling-related? → `styling.mdc`
-- Is this an integration? → `integrations.mdc`
-- Is this architectural? → `architecture.mdc`
-- Is this cross-cutting? → `main.mdc`
-
----
-
-## 🚀 For Developers
-
-### Quick Setup
-
-1. These rules are automatically loaded by Cursor AI
-2. All files have `alwaysApply: true` in frontmatter
-3. Files apply to: `*.tsx, *.jsx, *.css, *.js, *.ts`
-
-### Contributing
-
-When adding new guidelines:
-
-1. Choose the appropriate file
-2. Follow existing formatting patterns
-3. Add clear examples
-4. Update this README if needed
-5. Keep content focused and actionable
-
----
-
-## 📊 File Statistics
-
-| File               | Purpose                  | Key Topics                                                                         |
-| ------------------ | ------------------------ | ---------------------------------------------------------------------------------- |
-| `main.mdc`         | Overview & Cross-cutting | Tech stack, React 19+ features, Cache Components, React Compiler, Images, Dev/Prod |
-| `components.mdc`   | React & WebGL            | Components, Forms, WebGL, Three.js, Shaders, Activity                              |
-| `styling.mdc`      | All Styling              | CSS Modules, Tailwind v4, Responsive, Custom utilities                             |
-| `integrations.mdc` | Third-party Services     | Sanity, Shopify, HubSpot, Cache Components, cacheSignal                            |
-| `architecture.mdc` | Patterns & Quality       | State, Routing, Performance, Cache Components, Security, Testing                   |
-
----
-
-Last updated: 2025-12-18
-
-For questions or suggestions about these rules, contact the development team.
+Last updated: 2026-08-03

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -10,446 +10,168 @@ globs: *.tsx, *.jsx, *.css, *.js, *.ts
 
 ## Type Safety
 
-### TypeScript Configuration
-- Use TypeScript for all new code
-- Maintain strict type checking
-- Avoid `any` types unless absolutely necessary
-- Use proper type imports (`import type` when importing only types)
+- Strict TypeScript, avoid `any` unless truly necessary
+- `verbatimModuleSyntax: true` — use `import type` for type-only imports
 
 ```tsx
-import type { ComponentProps } from 'react'
+import type { ComponentProps } from "react";
 
-interface ButtonProps extends ComponentProps<'button'> {
-  variant?: 'primary' | 'secondary'
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: "primary" | "secondary";
 }
 ```
 
 ## State Management
 
 ### React Built-in State
-Prefer React's built-in state for component state. Keep state as close to where it's used as possible.
-
-```tsx
-function Component() {
-  const [count, setCount] = useState(0)
-  return <button onClick={() => setCount(count + 1)}>{count}</button>
-}
-```
+Prefer local state, kept as close to where it's used as possible.
 
 ### Zustand for Global State
-Use Zustand for global state when needed. Define stores in `@/lib/store.ts` or dedicated store files.
+Global state (e.g. transitions, theme-adjacent state) lives in Zustand stores under
+`hooks/` (or a dedicated store file, see `example/store.ts` for a reference pattern).
 
 ```tsx
-import { create } from 'zustand'
+import { create } from "zustand";
 
 interface CartStore {
-  items: CartItem[]
-  addItem: (item: CartItem) => void
-  removeItem: (id: string) => void
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
 }
 
 export const useCartStore = create<CartStore>((set) => ({
   items: [],
   addItem: (item) => set((state) => ({ items: [...state.items, item] })),
-  removeItem: (id) => set((state) => ({ 
-    items: state.items.filter(item => item.id !== id) 
-  })),
-}))
+}));
 ```
-
-### State Management Best Practices
-- Keep state minimal and derived values computed
-- Use context for shared UI state (theme, modals)
-- Use Zustand for complex global state (cart, user)
-- Avoid prop drilling with composition patterns
 
 ## Routing & Navigation
 
-### Next.js App Router
-Use Next.js App Router conventions. Follow the file-based routing structure.
-
-```
-app/
-  (pages)/
-    home/
-      page.tsx
-    about/
-      page.tsx
-```
+Routes are configured in `app/routes.ts` (React Router 7's file-based/manual
+route config). Route modules live in `app/routes/`, with route-specific
+components colocated under `app/routes/**/components/` (or similar) — not in the
+top-level `components/` directory, which is for cross-route reusable pieces.
 
 ### Navigation
-Use the custom Link component for internal navigation. It automatically handles external links.
+Use `~/components/link`, which wraps React Router's `<Link>` for internal hrefs
+and falls back to a plain `<a target="_blank">`-style external link for absolute
+URLs, and to a `<button>`/`<div>` when there's no `href`.
 
 ```tsx
-import { Link } from '@/components/ui'
+import { Link } from "~/components/link";
 
-function Navigation() {
-  return (
-    <>
-      {/* Internal link - uses next/link */}
-      <Link href="/about">About</Link>
-      
-      {/* External link - uses <a> with target="_blank" */}
-      <Link href="https://example.com">External</Link>
-    </>
-  )
-}
+<Link href="/about">About</Link>
+<Link href="https://example.com">External</Link>
 ```
 
-### Metadata & SEO
-Use `@/utils/metadata` for SEO optimization. Generate metadata for all pages.
+## Data Loading
+
+Data fetching happens in React Router loaders, typed via the route's generated
+`Route` types.
 
 ```tsx
-import { generatePageMetadata } from '@/utils/metadata'
+export async function loader({ params }: Route.LoaderArgs) {
+  const data = await client.fetch(query, { slug: params.slug });
+  return { data };
+}
 
-export async function generateMetadata({ params }) {
-  const page = await fetchPage(params.slug)
-  
-  return generatePageMetadata({
-    title: page.title,
-    description: page.description,
-    image: { url: page.image },
-    url: `/pages/${params.slug}`,
-  })
+export default function Page({ loaderData }: Route.ComponentProps) {
+  const { data } = loaderData;
+  // ...
 }
 ```
 
-### Loading and Error States
-Implement proper loading and error states for all routes.
+## Root Layout Pattern (`app/root.tsx`)
 
-```tsx
-// loading.tsx
-export default function Loading() {
-  return <div>Loading...</div>
-}
+`Layout` renders the HTML shell (`<html>`, `<head>`, `<Meta>`, `<Links>`,
+`<Scripts>`, `<ScrollRestoration>`). The default `App` export composes:
 
-// error.tsx
-'use client'
+- **`ThemeProvider`** — wraps everything (`<Outlet />` and siblings), provides
+  theme context via React context + a `data-theme` attribute on `<html>`.
+- **`RealViewport`** — standalone, sets `--vw`/`--dvh`/`--svh`/`--scrollbar-width`
+  CSS custom properties via a RAF-driven external store, returns `null`.
+- **`ReactTempus`** (`tempus/react`) — standalone, drives the global RAF loop.
+- **`GlobalCanvas`** (`~/webgl/components/global-canvas`) — standalone,
+  lazy-loaded persistent WebGL canvas, wrapped in `<Suspense fallback={null}>`.
+- **`OrchestraTools`** (`@novus/orchestra`, lazy) — standalone dev-tools overlay;
+  present in `example/root.tsx`, gated by `process.env.NODE_ENV === "development"`.
+  A second, build-time mechanism exists for stripping dev-only modules from
+  static builds: the `devOnly()` helper in `components/dev-only.tsx`, driven by
+  the `__INCLUDE_DEV_TOOLS__` define in `vite.config.ts`.
 
-export default function Error({ error, reset }) {
-  return (
-    <div>
-      <h2>Something went wrong!</h2>
-      <button onClick={() => reset()}>Try again</button>
-    </div>
-  )
-}
-```
+Providers wrap children; standalone components return `null` and mutate global
+state/CSS variables as a side effect.
 
-## Performance
+## Workspace Packages (`packages/*`)
 
-### Server Components
-Use React Server Components by default. Only add 'use client' when needed.
+Bun workspaces, imported as `@novus/<name>`:
 
-```tsx
-// Server Component (default)
-async function ServerComponent() {
-  const data = await fetchData()
-  return <div>{data.title}</div>
-}
+| Package | Purpose |
+| --- | --- |
+| `@novus/font-optimizer` | Vite plugin + runtime for font subsetting/loading |
+| `@novus/image-optimizer` | Vite plugin for image processing/LQIP |
+| `@novus/orchestra` | Dev-tools overlay (grid, stats, minimap, Theatre.js) |
+| `@novus/password-protection` | React Router middleware + session for site password gating |
+| `@novus/static-i18n` | Build-time static i18n (config, loader, translations) |
+| `@novus/styling` | The `darkroom-styling` Vite plugin, Lightning CSS custom functions, design-token types |
+| `@novus/transitions` | Page transition system (`TransitionOutlet`, hooks, registry) |
 
-// Client Component (when needed)
-'use client'
-
-function ClientComponent() {
-  const [state, setState] = useState(0)
-  return <button onClick={() => setState(state + 1)}>{state}</button>
-}
-```
-
-### Code Splitting
-Use `next/dynamic` for heavy components. Implement proper loading states.
-
-```tsx
-import dynamic from 'next/dynamic'
-
-const HeavyComponent = dynamic(() => import('./HeavyComponent'), {
-  loading: () => <div>Loading...</div>,
-  ssr: false // if needed
-})
-```
-
-### Caching Strategies
-Follow Next.js 16 recommended caching strategies. Use appropriate revalidation times.
-
-```tsx
-// Static generation with revalidation
-export const revalidate = 3600 // 1 hour
-
-// Dynamic with specific cache tags
-export async function fetchData() {
-  const res = await fetch('https://api.example.com/data', {
-    next: { 
-      revalidate: 3600,
-      tags: ['data']
-    }
-  })
-  return res.json()
-}
-
-// User-specific data - NEVER cache
-export async function fetchUserCart(userId: string) {
-  const res = await fetch(`https://api.example.com/cart/${userId}`, {
-    cache: 'no-store' // Required for user-specific data
-  })
-  return res.json()
-}
-```
-
-### Cache Components (Next.js 16)
-
-Cache Components are enabled globally (`cacheComponents: true`). Key considerations:
-
-**Suspense Boundaries:**
-```tsx
-import { Suspense } from 'react'
-
-export default async function Page() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <DataComponent />
-    </Suspense>
-  )
-}
-```
-
-**Cache Invalidation:**
-```tsx
-import { revalidateTag, revalidatePath } from 'next/cache'
-
-// In webhook handlers
-export async function POST(request: Request) {
-  revalidateTag('products')
-  // or
-  revalidatePath('/products/[slug]', 'page')
-  return Response.json({ revalidated: true })
-}
-```
-
-**⚠️ Critical Rules:**
-- User-specific data: Always use `cache: 'no-store'`
-- Real-time data: Always use `cache: 'no-store'`
-- Test with hard refresh AND navigation
-- Wrap data fetching in Suspense boundaries
-
-### Asset Optimization
-- Always use the custom `Image` component (`@/components/ui/image`)
-- Optimize bundles with tree-shaking
-- Check bundle size impact of new dependencies
-- Use `bun lint` to check for linting issues
-
-## Request Proxy (`proxy.ts`)
-
-Next.js 16 replaces `middleware.ts` with a **request proxy** at the project root (`proxy.ts`). This handles cross-cutting concerns for incoming requests.
-
-- **Rate limiting**: API routes are rate-limited via `@/utils/rate-limit`. Adjust `rateLimiters` config per route pattern.
-- **Security headers**: Stay in `next.config.ts` (static, no need for proxy).
-- **Extensible**: Add auth, logging, or CORS by editing `proxy.ts`.
-
-```typescript
-// proxy.ts (project root)
-import { proxy } from './proxy'
-export { proxy, config } from './proxy'
-```
+These used to live under `lib/` in older starter revisions; they have since been
+extracted into standalone workspace packages. `lib/` today only contains
+`split-text/` (vendored split-text logic; `components/split-text.tsx` is the
+React wrapper around it).
 
 ## Security
 
-### Environment Variables & Validation Layer
-
-Environment variables are validated with **Zod schemas** at three boundaries:
-
-1. **Env boundary** -- `lib/env.ts` provides `env` object with type-safe access (parsed once at import)
-2. **Form boundary** -- `parseFormData()` and `zodToValidator()` validate user input on client and server
-3. **Server action boundary** -- `schema.safeParse()` validates before processing
+### Environment Variables & Validation
+Environment variables are validated once, at import, in the root `env.ts` using
+`@t3-oss/env-core` + `valibot` — not Zod.
 
 ```typescript
-// Typed env access (preferred over process.env)
-import { env } from '@/lib/env'
+import { env } from "~/env";
 
-const projectId = env.NEXT_PUBLIC_SANITY_PROJECT_ID // typed, validated
+const projectId = env.PUBLIC_SANITY_PROJECT_ID; // typed, validated
 ```
 
 - Never commit API keys
-- Use `.env.local` for development
-- Document required variables in `.env.example`
+- Use `.env` for local development (see `env.ts` for the full var list)
+- `SANITY_SESSION_SECRET` / `SESSION_SECRET` gate preview mode and password
+  protection sessions respectively — required only when those features are used
 
-### Input Validation
-Validate all user inputs with Zod. Server actions return `{ status, message, fieldErrors? }`.
-
-```tsx
-import { z } from 'zod'
-
-const contactSchema = z.object({
-  email: z.string().email(),
-  message: z.string().min(1),
-})
-
-async function submitForm(formData: FormData) {
-  'use server'
-  const result = contactSchema.safeParse(Object.fromEntries(formData))
-  if (!result.success) {
-    return { status: 400, message: 'Invalid input', fieldErrors: result.error.flatten().fieldErrors }
-  }
-  // Process validated data...
-  return { status: 200, message: 'Success' }
-}
-```
-
-### Authentication & Authorization
-- Implement proper authentication
-- Use server-side API calls for sensitive operations
-- Rate limiting is handled by `proxy.ts` for API routes
-- Follow CSP guidelines (configured in `next.config.ts`)
+### Authentication
+Site-wide password protection is opt-in via the `@novus/password-protection`
+middleware, registered in `app/root.tsx`'s `middleware` export.
 
 ## Testing & Debugging
 
-### Unit Testing
-Write unit tests for critical functionality.
-
-```tsx
-import { render, screen } from '@testing-library/react'
-import Button from './Button'
-
-test('renders button with text', () => {
-  render(<Button>Click me</Button>)
-  expect(screen.getByText('Click me')).toBeInTheDocument()
-})
-```
-
-### Debugging Tools
-- Use Orchestra tools for debugging (CMD+O)
-- Use Theatre.js Studio for animation debugging
-- Enable WebGL inspector in development (for WebGL)
+- Use `@novus/orchestra` (Orchestra dev tools) for grid overlays, stats,
+  minimap, and Theatre.js-driven animation debugging
 - Use React DevTools for component inspection
-
-### Error Boundaries
-Implement error boundaries for critical sections. Provide meaningful fallback UI.
-
-```tsx
-'use client'
-
-import { Component } from 'react'
-
-class ErrorBoundary extends Component {
-  state = { hasError: false }
-  
-  static getDerivedStateFromError(error) {
-    return { hasError: true }
-  }
-  
-  componentDidCatch(error, errorInfo) {
-    console.error('ErrorBoundary caught:', error, errorInfo)
-  }
-  
-  render() {
-    if (this.state.hasError) {
-      return <div>Something went wrong.</div>
-    }
-    
-    return this.props.children
-  }
-}
-```
-
-### Logging Best Practices
-- Use console.log for simple debugging (auto-stripped in production)
-- Use console.error and console.warn for important issues (kept in production)
-- Gate expensive debug operations with `process.env.NODE_ENV === 'development'`
-- Log errors with context for better debugging
+- Gate debug UI the way the root layouts do: `process.env.NODE_ENV ===
+  "development"` for dev-server-only rendering, or wrap the dynamic import with
+  `devOnly()` (`components/dev-only.tsx`) when the module must be tree-shaken
+  out of static builds via the `__INCLUDE_DEV_TOOLS__` define
 
 ## Code Quality
 
-### Linting & Formatting
-- Follow Biome linting rules
-- Run `bun lint` before committing
-- Maintain consistent code style
-- Fix linting errors immediately
-
-### Code Organization
-- Follow the defined project structure
-- Maintain separation of concerns
-- Use meaningful variable and function names
-- Write meaningful comments and documentation
-- Prefer named exports for utilities
-
-### Component Composition
-Follow component composition patterns. Keep components focused and reusable.
-
-```tsx
-// Good: Composable components
-function Card({ children, className }) {
-  return <div className={cn(s.card, className)}>{children}</div>
-}
-
-function CardHeader({ children }) {
-  return <div className={s.header}>{children}</div>
-}
-
-function CardBody({ children }) {
-  return <div className={s.body}>{children}</div>
-}
-
-// Usage
-<Card>
-  <CardHeader>Title</CardHeader>
-  <CardBody>Content</CardBody>
-</Card>
-```
+- Run `bun run check` (lint + format + typecheck) before committing
+- `bun run lint` runs Oxlint, `bun run format` runs Oxfmt — not Biome
+- Prefer named exports for utilities; named function declarations for components
 
 ## Development Workflow
 
 ### Package Manager
-Use Bun as the JavaScript runtime and package manager.
+Bun, with `workspaces: ["packages/*"]`.
 
 ```bash
-# Install dependencies
-bun install
-
-# Run development server (with Turbopack)
-bun dev
-
-# Build for production
-bun run build
-
-# Run linting
-bun lint
+bun install          # install dependencies (root + workspace packages)
+bun dev              # dev server
+bun run build        # production build
+bun run check        # lint + format + typecheck
 ```
 
 ### Git Workflow
-- Write meaningful commit messages
-- Use conventional commits when possible
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`
+- No force push to `main`
 - Review changes before committing
-- DO NOT use `git push --force` without permission
-- DO NOT skip hooks (--no-verify) unless explicitly requested
 
-### Client/Server Boundaries
-Keep client/server boundaries clear. Understand when code runs where.
-
-```tsx
-// Server Component
-async function ServerComponent() {
-  'use server' // Optional annotation
-  const data = await fetchData() // Runs on server
-  return <ClientComponent data={data} />
-}
-
-// Client Component
-'use client'
-
-function ClientComponent({ data }) {
-  const [state, setState] = useState(data) // Runs on client
-  return <div>{state}</div>
-}
-```
-
-## Best Practices Summary
-
-1. **Type Safety**: Use TypeScript everywhere, avoid `any`
-2. **State Management**: React state first, Zustand for global needs
-3. **Performance**: Server components by default, code splitting for heavy components
-4. **Security**: Validate inputs, secure environment variables, server-side sensitive operations
-5. **Testing**: Write tests for critical paths, use debugging tools effectively
-6. **Code Quality**: Follow linting rules, maintain consistent style, write meaningful documentation
-7. **Development**: Use Bun, follow git best practices, understand client/server boundaries
-
-Last updated: 2026-02-06
+Last updated: 2026-08-03

--- a/.cursor/rules/components.mdc
+++ b/.cursor/rules/components.mdc
@@ -11,446 +11,232 @@ globs: *.tsx, *.jsx, *.js, *.ts
 ## Imports and Dependencies
 
 ### Utility Functions
-Always use `cn` from `clsx` for className conditionals
+Always use `cn` from `clsx` for className conditionals.
 
 ```tsx
-import cn from 'clsx'
+import cn from "clsx";
 
-function MyComponent({ className }) {
-  return <div className={cn(s.component, className)} />
+function MyComponent({ className }: { className?: string }) {
+  return <div className={cn(s.component, className)} />;
 }
 ```
 
-### Base UI Components
-Use components from `@base-ui/react` when available
-
-```tsx
-import { Select } from '@base-ui/react/select'
-```
-
 ### Animation Libraries
-- Use `gsap` for complex animations
-- Use `lenis` for smooth scrolling
-- Use `tempus` for timing utilities
-- Use `hamo` for DOM utilities
+- Use `animejs` for complex/keyframe animations
+- Use `lenis` for smooth scrolling (`components/lenis`)
+- Use `tempus` (`tempus/react`'s `ReactTempus`) for the shared RAF loop
+- Use `hamo` for DOM utilities (e.g. `useRect`)
 
 ## Component Structure
 
 ### CSS Modules
-Use CSS modules for component styling. Import styles as `s`
+Use CSS modules for component styling, colocated with the component. Import as `s`.
 
 ```tsx
-import s from './component-name.module.css'
-```
-
-### Client Components
-Add 'use client' directive for client components
-
-```tsx
-'use client'
-
-import { useState } from 'react'
+import s from "./component-name.module.css";
 ```
 
 ### Props Interface
-Define props interface at the top of the file. Extend HTML attributes when appropriate.
+Define the props interface at the top of the file, extending the relevant HTML
+element's props when appropriate.
 
 ```tsx
-import type { ComponentProps } from 'react'
+import type { ComponentProps } from "react";
 
-interface ButtonProps extends ComponentProps<'button'> {
-  variant?: 'primary' | 'secondary'
-  size?: 'sm' | 'md' | 'lg'
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: "primary" | "secondary";
 }
 ```
 
 ### React 19 Ref Handling
-In React 19, ref is passed as a regular prop (no forwardRef needed)
+`ref` is a regular prop — no `forwardRef` needed.
 
 ```tsx
-// Old pattern (React 18)
-// const Button = forwardRef<HTMLButtonElement, ButtonProps>(...)
-
-// New pattern (React 19)
-function Button({ ref, variant = 'primary', ...props }: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) {
-  return <button ref={ref} {...props} />
+function Button({ ref, variant = "primary", ...props }: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) {
+  return <button ref={ref} {...props} />;
 }
 ```
 
-### Default Exports
-Use named function declarations for components. Export the component as default.
+### Function Declarations, Named Exports
+Use named function declarations (not arrow functions) for components. Prefer
+named exports; a `default export` is required only for components loaded via
+`React.lazy`.
 
 ```tsx
-function Button({ variant = 'primary', size = 'md', ...props }: ButtonProps) {
-  // component logic
+export function Button({ variant = "primary", ...props }: ButtonProps) {
+  return <button {...props} />;
 }
-
-export default Button
 ```
 
-## Form Components
+### Filenames
+Kebab-case filenames (`split-text.tsx`, `real-viewport.tsx`, `scroll-restoration.tsx`).
 
-### Form Handling
-- Use custom form hooks when appropriate
-- Connect to integrations for external services
-- Implement proper validation
+## Reusable Components (`components/`)
+
+| Component | Purpose |
+| --- | --- |
+| `image.tsx` | `<Image>` — wraps `@responsive-image/react`, mobile/desktop size hints |
+| `link.tsx` | `<Link>` — wraps React Router's `Link`, handles external/no-href/no-op cases |
+| `wrapper.tsx` | `<Wrapper>` — per-route content wrapper, opts into WebGL canvas + Lenis |
+| `theme.tsx` | `<ThemeProvider>` / `useTheme()` — theme context + `data-theme` attribute |
+| `lenis/` | `<Lenis>` — smooth-scroll wrapper |
+| `marquee/` | Marquee/ticker component |
+| `fold/` | Fold/accordion-style component |
+| `scrollbar/` | Custom scrollbar |
+| `progress-text/` | Scroll/time-driven progress text reveal |
+| `split-text.tsx` | React wrapper around `lib/split-text` |
+| `real-viewport.tsx` | `<RealViewport>` — sets `--vw`/`--dvh`/`--svh` CSS vars, returns `null` |
+| `scroll-restoration.tsx` | Scroll position restoration on navigation |
+| `dev-only.tsx` | `devOnly()` — wraps a dynamic import so dev-only code is dropped from static builds |
+| `seo.tsx` | SEO/meta helpers |
+
+## Lazy Loading
+
+Components loaded via `React.lazy` **must** use `export default`.
 
 ```tsx
-import { useForm } from '@/components/ui/form/hook'
-import { HubspotNewsletterAction } from '@/lib/integrations/hubspot/action'
-```
+// component.tsx
+export default function HeavyComponent() { /* ... */ }
 
-### Server Actions
-Use Server Actions for form submissions when possible. Implement proper error handling.
-
-```tsx
-async function submitForm(formData: FormData) {
-  'use server'
-  // server-side logic
-}
+// usage
+const HeavyComponent = lazy(() => import("./component"));
 ```
 
 ## Responsive Design
 
-### Device Detection
-Use `useDeviceDetection` hook from `@/hooks/use-device-detection` for responsive logic
+### Viewport Values
+Use `useViewport()` from `~/components/real-viewport` for viewport-driven values
+(re-renders only on selected value change via `useSyncExternalStore`).
 
 ```tsx
-import { useDeviceDetection } from '@/hooks/use-device-detection'
+import { useViewport } from "~/components/real-viewport";
 
-function ResponsiveComponent() {
-  const { isMobile } = useDeviceDetection()
-  return isMobile ? <MobileVersion /> : <DesktopVersion />
-}
+const dvh = useViewport((state) => state.dvh);
 ```
 
-### Viewport Units
-Use custom viewport units for responsive values (see styling.mdc for details)
+### Viewport Functions (CSS)
+Use the custom Lightning CSS functions for responsive sizing (see `styling.mdc`).
 
 ```css
 .element {
   width: mobile-vw(150);
-  margin-top: desktop-vh(100);
+  margin-top: desktop-vw(50);
 }
 ```
 
-## Performance Best Practices
+## Performance
 
-### Code Splitting
-Use `next/dynamic` for heavy components
+### No Manual Memoization
+See `main.mdc` — React Compiler handles memoization. Do not use `useMemo`,
+`useCallback`, or `React.memo` in app code.
 
-```tsx
-import dynamic from 'next/dynamic'
-
-const HeavyComponent = dynamic(() => import('./HeavyComponent'), {
-  loading: () => <div>Loading...</div>,
-  ssr: false // if needed
-})
-```
-
-### Memoization
-See main.mdc for React Compiler guidance - manual memoization is rarely needed.
-
-## Error Handling
-
-### Error Boundaries
-Implement error boundaries for critical sections. Provide meaningful fallback UI.
-
-### Loading States
-Always handle loading states. Use Suspense boundaries where appropriate.
+### Lazy Loading Heavy Components
+Use `React.lazy` + `Suspense` for heavy components (WebGL scenes, dev tools,
+the transitions system), as done for `GlobalCanvas` and `OrchestraTools` in
+`app/root.tsx` / `example/root.tsx`.
 
 ---
 
-# WebGL Components
+# WebGL Components (`webgl/`)
 
-## React Three Fiber Setup
+## Structure
 
-### Canvas Component
-Use the custom Canvas wrapper from `@/lib/webgl/components/canvas`
+```
+webgl/
+  components/
+    canvas/            # <Canvas> — R3F canvas wrapper, used by <Wrapper webgl>
+    global-canvas/      # persistent lazy-loaded canvas mounted once in root.tsx
+    image/              # WebGL-aware image (DOM fallback + texture)
+    tunnel/              # WebGLTunnel / DOMTunnel — portal children into/out of the canvas
+    flowmap-provider/
+    postprocessing/
+    preload/
+    raf/
+  hooks/
+  store.ts
+  types.d.ts
+  utils/
+```
+
+## Canvas & Tunnel Pattern
+
+`<Wrapper webgl>` renders `<Canvas root={webgl}>` from `webgl/components/canvas`
+around route content. To render actual 3D content, teleport JSX into the
+canvas with `WebGLTunnel` (React contexts from the DOM tree are not available
+inside R3F's separate reconciler, so `WebGLTunnel` uses `tunnel-rat` +
+`useContextBridge` to bridge them across):
 
 ```tsx
-import { Canvas } from '@/lib/webgl/components/canvas'
+import { WebGLTunnel } from "~/webgl/components/tunnel";
 
 function Scene() {
   return (
-    <Canvas
-      camera={{ position: [0, 0, 5], fov: 50 }}
-      gl={{ antialias: true, alpha: true }}
-    >
-      {/* 3D content */}
-    </Canvas>
-  )
+    <WebGLTunnel>
+      <mesh>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="hotpink" />
+      </mesh>
+    </WebGLTunnel>
+  );
 }
 ```
 
-## WebGL File Organization
-
-Separate WebGL logic into `webgl.tsx` files. Keep React logic in main component files.
-
-```
-components/
-  scene/
-    index.tsx         # React component
-    webgl.tsx         # Three.js logic
-    scene.module.css  # Styles
-```
-
-### WebGL Component Pattern
+## React Three Fiber
 
 ```tsx
-// scene/webgl.tsx
-import { useFrame } from '@react-three/fiber'
-import { useRef } from 'react'
-import type { Mesh } from 'three'
+import { useFrame } from "@react-three/fiber";
+import { useRef } from "react";
+import type { Mesh } from "three";
 
-export default function SceneWebGL() {
-  const meshRef = useRef<Mesh>(null)
-  
-  useFrame((state, delta) => {
+export function SceneWebGL() {
+  const meshRef = useRef<Mesh>(null);
+
+  useFrame((_state, delta) => {
     if (meshRef.current) {
-      meshRef.current.rotation.y += delta
+      meshRef.current.rotation.y += delta;
     }
-  })
-  
-  // Simple logs are auto-stripped in production by Next.js
-  console.log('SceneWebGL rendered')
-  
+  });
+
   return (
     <mesh ref={meshRef}>
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color="hotpink" />
     </mesh>
-  )
+  );
 }
 ```
 
-## Drei Components
-
-### Common Helpers
-Use Drei components for common functionality
+## Drei & Post-Processing
 
 ```tsx
-import {
-  OrbitControls,
-  PerspectiveCamera,
-  Environment,
-  useGLTF,
-  useTexture
-} from '@react-three/drei'
+import { OrbitControls, useGLTF, useTexture } from "@react-three/drei";
+import { CopyPass, EffectComposer, RenderPass } from "postprocessing"; // vanilla package, wired manually in webgl/components/postprocessing/
 ```
 
-### Loading Assets
-Preload assets using Drei hooks. Implement proper loading states.
+## Object Instantiation — Always `useRef`
+
+Creating new object instances on every render creates new references that
+trigger effects, causing infinite loops. This is the one exception to "no
+manual memoization/refs for optimization":
 
 ```tsx
-// Preload in separate component
-function Preload() {
-  const start = performance.now()
-  useGLTF.preload('/models/model.glb')
-  useTexture.preload('/textures/texture.jpg')
-  // Console logs auto-stripped in production by Next.js
-  console.log(`Preload took ${performance.now() - start}ms`)
-  return null
-}
-```
+// DON'T: causes infinite re-renders when passed to effects/deps
+const flowmap = new Flowmap();
 
-## Custom Shaders
-
-### Shader Materials
-Use template literals for GLSL. Implement proper uniforms.
-
-```tsx
-import { shaderMaterial } from '@react-three/drei'
-import { extend } from '@react-three/fiber'
-
-const CustomMaterial = shaderMaterial(
-  { uTime: 0, uColor: new THREE.Color(0.0, 0.0, 0.0) },
-  vertexShader,
-  fragmentShader
-)
-
-extend({ CustomMaterial })
-```
-
-### GLSL Best Practices
-- Keep shaders in separate files when complex
-- Use proper precision qualifiers
-- Comment complex calculations
-
-```glsl
-precision mediump float;
-
-uniform float uTime;
-varying vec2 vUv;
-
-void main() {
-  // Shader logic
-}
-```
-
-## Animation & Interaction
-
-### Animation Loops
-Use `useFrame` for frame-based animations. Consider performance impact.
-
-```tsx
-useFrame((state, delta) => {
-  // Animation logic
-}, priority) // Lower priority = runs first
-```
-
-### Interaction
-Use Drei's interaction helpers. Implement proper hover/click states.
-
-```tsx
-import { useCursor } from '@react-three/drei'
-
-function InteractiveObject() {
-  const [hovered, setHovered] = useState(false)
-  useCursor(hovered)
-  
-  return (
-    <mesh
-      onPointerOver={() => setHovered(true)}
-      onPointerOut={() => setHovered(false)}
-    >
-      {/* geometry and material */}
-    </mesh>
-  )
-}
-```
-
-## Post-Processing
-
-### Effect Composer
-Use postprocessing library for effects. Chain effects efficiently.
-
-```tsx
-import { EffectComposer, Bloom, ChromaticAberration } from '@react-three/postprocessing'
-
-function Effects() {
-  return (
-    <EffectComposer>
-      <Bloom intensity={1.5} />
-      <ChromaticAberration offset={[0.002, 0.002]} />
-    </EffectComposer>
-  )
-}
-```
-
-### Performance Considerations
-- Limit number of passes
-- Use lower resolution for effects when possible
-- Profile performance impact
-
-## WebGL Best Practices
-
-### Memory Management
-Dispose of geometries and materials when components unmount. Clean up in useEffect return for complex resources. React Compiler handles most cleanup automatically.
-
-```tsx
-useEffect(() => {
-  // Only for complex resources that need explicit disposal
-  return () => {
-    geometry.dispose()
-    material.dispose()
-    texture.dispose()
-  }
-}, [geometry, material, texture])
-```
-
-### Performance Optimization
-See main.mdc for React Compiler guidance. For WebGL-specific object instantiation, always use `useRef`:
-
-```tsx
-// ⚠️ EXCEPTION: Object instantiation MUST use useRef to prevent infinite loops
-// Creating new objects on every render creates new references that trigger effects
-
-// ❌ DON'T: This causes infinite re-renders
-const flowmap = new Flowmap()
-
-// ✅ DO: Use useRef for object instantiation
-const flowmapRef = useRef<Flowmap | null>(null)
+// DO: use useRef for object instantiation
+const flowmapRef = useRef<Flowmap | null>(null);
 if (!flowmapRef.current) {
-  flowmapRef.current = new Flowmap(gl, { size: 128 })
+  flowmapRef.current = new Flowmap(gl, { size: 128 });
 }
-const flowmap = flowmapRef.current
+const flowmap = flowmapRef.current;
 ```
 
-### Responsive Design
-Handle window resizing. Adjust quality based on device capabilities.
+## Debugging
 
-```tsx
-const { viewport } = useThree()
-// Use viewport.width, viewport.height for responsive sizing
-```
+- Use `@novus/orchestra` (Theatre.js, stats, grid, minimap) for animation and
+  performance debugging
+- Gate debug UI with `devOnly()` (`components/dev-only.tsx`) or the
+  `__INCLUDE_DEV_TOOLS__` build define, not `NODE_ENV` alone — Oxlint/Vite do
+  not automatically strip debug components the way a framework compiler might
 
-## React 19.2 Activity Integration
-
-Use `<Activity />` to optimize WebGL performance by deferring off-screen scenes:
-
-```tsx
-import { Activity, useEffect, useRef, useState } from 'react'
-import { useRect } from 'hamo'
-import { WebGLTunnel } from '@/lib/webgl/components/tunnel'
-
-export function WebGLScene({ className }) {
-  const [setRectRef, rect] = useRect()
-  const [isVisible, setIsVisible] = useState(true)
-  const elementRef = useRef<HTMLDivElement | null>(null)
-
-  // Intersection Observer with 200px margin for pre-activation
-  useEffect(() => {
-    const element = elementRef.current
-    if (!element) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { rootMargin: '200px' }
-    )
-
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [])
-
-  return (
-    // Wrap DOM container - defers rect tracking when off-screen
-    <Activity mode={isVisible ? 'visible' : 'hidden'}>
-      <div ref={(el) => { setRectRef(el); elementRef.current = el }} className={className}>
-        {/* WebGL content goes in WebGLTunnel (no Activity wrapper needed) */}
-        <WebGLTunnel>
-          <WebGLComponent rect={rect} />
-        </WebGLTunnel>
-      </div>
-    </Activity>
-  )
-}
-```
-
-**Pattern**: `<Activity />` → DOM container → `WebGLTunnel` → WebGL content
-
-### Debugging
-- Use Theatre.js for animation debugging
-- Enable WebGL inspector in development
-- **Always gate debug UI components** - these are NOT auto-removed
-- Simple console logs are auto-stripped in production by Next.js
-
-```tsx
-// Simple logs: Auto-stripped in production
-console.log('WebGL state:', { fps, drawCalls, triangles })
-
-// Debug components: MUST be gated (not auto-removed)
-{process.env.NODE_ENV === 'development' && <Stats />}
-{process.env.NODE_ENV === 'development' && <Perf />}
-```
-
-### Mobile Optimization
-- Reduce polygon count for mobile
-- Use simpler shaders
-- Implement touch controls
-
-```tsx
-const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-```
-
-Last updated: 2025-12-18
+Last updated: 2026-08-03

--- a/.cursor/rules/integrations.mdc
+++ b/.cursor/rules/integrations.mdc
@@ -2,182 +2,77 @@
 alwaysApply: true
 ---
 ---
-description: Third-party integration guidelines (Sanity, Shopify, HubSpot, etc.)
+description: Third-party integration guidelines (Sanity)
 globs: *.tsx, *.jsx, *.css, *.js, *.ts
 ---
 
 # Third-Party Integration Guidelines
 
+Novus ships one first-party integration: **Sanity CMS**, organized under
+`integrations/sanity/`. There is no e-commerce or forms/CRM integration in this
+project — do not introduce integration guidance without a corresponding
+directory under `integrations/`.
+
 ## Sanity CMS Integration
 
-### Configuration & Setup
-Use CDN for performance with stega for visual editing. Store credentials securely in environment variables. All Sanity files are organized in `/lib/integrations/sanity/` directory.
+### Project Structure
+
+```
+integrations/sanity/
+├── client.ts           # public/CDN client (createClient)
+├── client.server.ts     # server client with read token, useCdn: false
+├── loader.server.ts     # @sanity/react-loader wiring (setServerClient)
+├── image.ts             # urlForImage() via @sanity/image-url
+├── queries.ts           # GROQ queries (pageQuery, articleQuery, allArticlesQuery)
+├── session.ts            # preview-mode cookie session (getPreviewData, etc.)
+├── seo.tsx               # SEO component reading a Sanity document's metadata field
+└── index.ts               # re-exports client, urlForImage, queries
+```
+
+### Environment Variables
+
+Validated in the root `env.ts` with `@t3-oss/env-core` + `valibot`, using a
+`PUBLIC_` prefix for client-exposed vars — not any other framework's client-env
+convention. Actual variable names, verified from `env.ts`:
+
+| Variable | Side | Purpose |
+| --- | --- | --- |
+| `PUBLIC_SANITY_PROJECT_ID` | client | Sanity project ID |
+| `PUBLIC_SANITY_DATASET` | client | Dataset name (defaults to `"production"`) |
+| `PUBLIC_SANITY_API_VERSION` | client | API version (defaults to `"2025-10-30"`) |
+| `PUBLIC_SANITY_STUDIO_URL` | client | Studio URL for stega visual editing |
+| `SANITY_API_READ_TOKEN` | server | Read token for the server client |
+| `SANITY_SESSION_SECRET` | server | Signs the `__sanity_preview` cookie; required for preview mode |
 
 ```typescript
-// In lib/integrations/sanity/client.ts
+// integrations/sanity/client.ts
+import { createClient } from "@sanity/client";
+import { env } from "~/env";
+
 export const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
-  apiVersion: '2024-03-15',
-  useCdn: true, // Use CDN for better performance
-  token: process.env.SANITY_API_WRITE_TOKEN, // Write token for editing
+  projectId: env.PUBLIC_SANITY_PROJECT_ID ?? "",
+  dataset: env.PUBLIC_SANITY_DATASET || "production",
+  apiVersion: env.PUBLIC_SANITY_API_VERSION || "2025-10-30",
+  useCdn: true,
   stega: {
-    studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || '/studio',
+    studioUrl: env.PUBLIC_SANITY_STUDIO_URL || "http://localhost:5173/studio",
   },
-})
+});
 ```
 
-### Schema Management
-
-#### Content Modelling
-- Unless explicitly modelling web pages or app views, create content models for what things are, not what they look like in a front-end
-- For example, consider the `status` of an element instead of its `color`
-
-#### Basic Schema Types
-- ALWAYS use the `defineType`, `defineField`, and `defineArrayMember` helper functions
-- ALWAYS write schema types to their own files and export a named `const` that matches the filename
-- ONLY use a `name` attribute in fields unless the `title` needs to be something other than a title-case version of the `name`
-- ANY `string` field type with an `options.list` array with fewer than 5 options must use `options.layout: "radio"`
-- ANY `image` field must include `options.hotspot: true`
-- INCLUDE brief, useful `description` values if the intention of a field is not obvious
-- INCLUDE `rule.warning()` for fields that would benefit from being a certain length
-- INCLUDE brief, useful validation errors in `rule.required().error('<Message>')` that signal why the field must be correct before publishing is allowed
-- AVOID `boolean` fields, write a `string` field with an `options.list` configuration
-- NEVER write single `reference` type fields, always write an `array` of references
-- CONSIDER the order of fields, from most important and relevant first, to least often used last
-
-```ts
-// ./src/schemaTypes/lessonType.ts
-import {defineField, defineType} from 'sanity'
-
-export const lessonType = defineType({
-  name: 'lesson',
-  title: 'Lesson',
-  type: 'document',
-  fields: [
-    defineField({
-      name: 'title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'categories',
-      type: 'array',
-      of: [defineArrayMember({type: 'reference', to: {type: 'category'}})],
-    }),
-  ],
-})
-```
-
-#### Schema Type with Custom Input Components
-If a schema type has input components, they should be colocated with the schema type file. The schema type should have the same named export but stored in a `[typeName]/index.ts` file:
-
-```ts
-// ./src/schemaTypes/seoType/index.ts
-import {defineField, defineType} from 'sanity'
-import seoInput from './seoInput'
-
-export const seoType = defineType({
-  name: 'seo',
-  title: 'SEO',
-  type: 'object',
-  components: { input: seoInput }
-  // ...
-})
-```
-
-#### No Anonymous Reusable Schema Types
-ANY schema type that benefits from being reused in multiple document types should be registered as its own custom schema type.
-
-```ts
-// ./src/schemaTypes/blockContentType.ts
-import {defineField, defineType} from 'sanity'
-
-export const blockContentType = defineType({
-  name: 'blockContent',
-  title: 'Block content',
-  type: 'array',
-  of: [defineField({name: 'block',type: 'block'})],
-})
-```
-
-#### Decorating Schema Types
-Every `document` and `object` schema type should:
-
-- Have an `icon` property from `@sanity/icons`
-- Have a customized `preview` property that shows rich contextual details about the document
-- Use `groups` when the schema type has more than a few fields to collate related fields and only show the most important group by default. These `groups` should use the icon property as well.
-- Use `fieldsets` with `options: {columns: 2}` if related fields could be grouped visually together, such as `startDate` and `endDate`
-
-### Visual Editing
-Always add `data-sanity` attributes for visual editing. Use SanityContextProvider for document access. Implement proper draft mode handling. Import from `/lib/integrations/sanity` directory.
-
-```typescript
-import { RichText } from '@/integrations/sanity/components/rich-text'
-
-export function MyComponent() {
-  const { document } = useSanityContext()
-  
-  return (
-    <div data-sanity={document._id}>
-      <h1 data-sanity="title">{document.title}</h1>
-      <div data-sanity="content">
-        <RichText content={document.content} />
-      </div>
-    </div>
-  )
-}
-```
-
-### Data Fetching
-Use proper perspective for draft vs published content. Implement caching strategies for performance. Handle errors gracefully with try-catch. Import from `/lib/integrations/sanity` directory. Use `@/utils/metadata` helpers for SEO optimization. All `sanityFetch` calls automatically use `cacheSignal()` for request cleanup.
-
-```typescript
-// In lib/integrations/sanity/queries/index.ts
-import { sanityFetch } from '@/integrations/sanity/live'
-import { generateSanityMetadata } from '@/utils/metadata'
-
-// Use sanityFetch (automatically includes cacheSignal)
-export async function fetchSanityPage(slug: string, isDraftMode = false) {
-  const { data, error } = await sanityFetch({
-    query: pageQuery,
-    params: { slug },
-    isDraftMode
-  })
-  
-  if (error) {
-    console.error('fetchSanityPage error:', error)
-    return { data: null, error }
-  }
-  
-  return { data, error: null }
-}
-
-// In page.tsx for SEO
-export async function generateMetadata({ params }) {
-  const { data } = await fetchSanityPage(params.slug)
-  return generateSanityMetadata(data)
-}
-```
-
-**Cache Components Notes:**
-- Draft mode automatically uses `cache: 'no-store'` ✅
-- Published content uses ISR with revalidation ✅
-- All queries use `cacheSignal()` for automatic cleanup ✅
-- Wrap in Suspense boundaries for proper loading states ✅
+The server client (`client.server.ts`) wraps the public client with a read
+token and `useCdn: false`, for use in loaders that need fresh/draft data.
 
 ### GROQ Queries
 
-- ALWAYS use SCREAMING_SNAKE_CASE for variable names, for example POSTS_QUERY
-- ALWAYS write queries to their own variables, never as a parameter in a function
-- ALWAYS import the `defineQuery` function to wrap query strings from the `groq` or `next-sanity` package
-- ALWAYS write every required attribute in a projection when writing a query
-- ALWAYS put each segment of a filter, and each attribute on its own line
-- ALWAYS use parameters for variables in a query
-- NEVER insert dynamic values using string interpolation
+- ALWAYS write queries to their own exported `const` in `integrations/sanity/queries.ts`
+- ALWAYS use `groq` template tag (imported from the `groq` package) to wrap query strings
+- ALWAYS write every required attribute in a projection
+- ALWAYS use parameters (`$slug`, etc.) for variables — never string interpolation
 
-```ts
-// In lib/integrations/sanity/queries/index.ts
-import { groq } from 'next-sanity'
+```typescript
+// integrations/sanity/queries.ts
+import groq from "groq";
 
 export const pageQuery = groq`
   *[_type == "page" && slug.current == $slug][0] {
@@ -185,353 +80,89 @@ export const pageQuery = groq`
     title,
     slug,
     content,
-    "imageUrl": image.asset->url,
+    metadata,
+    publishedAt,
     _updatedAt
   }
-`
-
-// Good query example
-import {defineQuery} from 'groq'
-
-export const POST_QUERY = defineQuery(`*[
-  _type == "post"
-  && slug.current == $slug
-][0]{
-  _id,
-  title,
-  image,
-  author->{
-    _id,
-    name
-  }
-}`)
+`;
 ```
 
-### Performance Optimization
-Use ISR for static content with revalidation. Implement proper cache invalidation via webhooks. Optimize images with proper sizing. Use consolidated imports for better tree-shaking. Use metadata helpers for consistent SEO.
+### Data Fetching (Loaders)
 
-```typescript
-import { urlForImage } from '@/integrations/sanity/utils/image'
-import { generateSanityMetadata } from '@/utils/metadata'
+Fetch Sanity data in React Router loaders, not in components.
 
-// Use ISR for published content
-export const revalidate = 3600
+```tsx
+import { client } from "~/integrations/sanity";
+import { pageQuery } from "~/integrations/sanity/queries";
 
-// Optimize images
-<SanityImage image={document.image} maxWidth={1200} />
-
-// Generate SEO metadata
-export async function generateMetadata({ params }) {
-  const page = await fetchSanityPage(params.slug)
-  return generateSanityMetadata(page, {
-    title: page.seo?.title || page.title,
-    description: page.seo?.description,
-    image: page.seo?.image || page.image,
-    noIndex: page.seo?.noIndex,
-  })
+export async function loader({ params }: Route.LoaderArgs) {
+  const page = await client.fetch(pageQuery, { slug: params.slug });
+  return { page };
 }
 ```
 
-### Project Structure
-All Sanity files are organized in `/lib/integrations/sanity/` directory
+For preview/draft mode, use `loader.server.ts`'s `loadQuery` (wired via
+`@sanity/react-loader` + `setServerClient`) together with `session.ts`'s
+`getPreviewData(request)`, which reads the `__sanity_preview` cookie session
+to decide `perspective: "drafts" | "published"` and whether `stega` is enabled.
 
-```
-lib/integrations/sanity/
-├── sanity.cli.ts           # CLI configuration
-├── sanity.config.ts        # Studio configuration
-├── env.ts                  # Environment variables
-├── structure.ts            # Studio structure
-├── client.ts               # Sanity client
-├── fetch.ts                # Data fetching with cacheSignal
-├── index.ts                # Main exports
-├── README.md               # Documentation
-├── queries/
-│   └── index.ts            # GROQ queries
-├── schemaTypes/            # Content type definitions
-│   ├── documents/          # Document types (article, page, etc.)
-│   ├── objects/            # Object types (link, metadata, richText)
-│   ├── singletons/         # Singleton types (navigation)
-│   └── index.ts
-├── components/             # React components
-│   ├── context.tsx         # React context
-│   ├── rich-text.tsx       # Rich text component
-│   └── disable-draft-mode.tsx
-└── utils/
-    ├── image.ts            # Image utilities
-    └── link.ts             # Link utilities
+### Images
+
+Use `urlForImage()` (wraps `@sanity/image-url`) to build image URLs, and pass
+the result through `~/components/image`'s `<Image>` rather than a raw `<img>`.
+
+```typescript
+import { urlForImage } from "~/integrations/sanity/image";
+
+const url = urlForImage(document.image).width(1200).url();
 ```
 
-### Writing Sanity Content for Importing
+### SEO
 
-When asked to write content:
+`integrations/sanity/seo.tsx` reads a Sanity document's `metadata` field
+(falling back to `title`/`excerpt`) and renders `~/components/seo`'s `<SEO>`
+component — use this instead of hand-rolling meta tags for Sanity-backed pages.
 
-- ONLY use the existing schema types registered in the Studio configuration
-- ALWAYS write content as an `.ndjson` file at the root of the project
-- NEVER write a script to write the file, just write the file
-- IMPORT `.ndjson` files using the CLI command `npx sanity dataset import <filename.ndjson>`
-- NEVER include a `.` in the `_id` field of a document unless you need it to be private
-- NEVER include image references because you don't know what image documents exist
-- ALWAYS write images in this format below, replacing the document ID value to generate the same placeholder image
+### Schema Management (Sanity Studio)
 
-```JSON
-{"_type":"image","_sanityAsset":"image@https://picsum.photos/seed/[[REPLACE_WITH_DOCUMENT_ID]]/1920/1080"}
+- ALWAYS use `defineType`, `defineField`, and `defineArrayMember` helper functions
+- ALWAYS write schema types to their own files and export a named `const` matching the filename
+- ONLY use a `name` attribute in fields unless `title` needs to differ from a title-case version of `name`
+- ANY `image` field must include `options.hotspot: true`
+- NEVER write single `reference` fields — always an `array` of references
+- AVOID `boolean` fields; prefer a `string` field with an `options.list`
+
+```ts
+import { defineField, defineType } from "sanity";
+
+export const pageType = defineType({
+  name: "page",
+  title: "Page",
+  type: "document",
+  fields: [
+    defineField({ name: "title", type: "string" }),
+  ],
+});
 ```
 
 ### TypeScript Generation
 
-#### For the Studio
-ALWAYS re-run schema extraction after making schema file changes with `npx sanity@latest schema extract`
+After schema or query changes, regenerate types per the Sanity CLI docs
+(`npx sanity@latest schema extract` / `typegen generate`) if a Studio is
+configured for this project.
 
-#### For Monorepos
-ALWAYS use a simple pnpm workspace configuration to place the studio in `apps/studio`
+## Opt-in `lib/` and `packages/` Modules
 
-```
-your-project/
-└── apps/
-    ├── studio/ -> Sanity Studio
-    └── web/    -> Front-end
-```
+These are not "integrations" in the third-party-API sense, but are opt-in
+building blocks worth knowing about:
 
-- ALWAYS extract the schema to the web folder with `npx sanity@latest schema extract --path=../<front-end-folder>/sanity/extract.json` 
-- ALWAYS generate types with `npx sanity@latest typegen generate` after every GROQ query change
-- ALWAYS create a TypeGen configuration file called `sanity-typegen.json` at the root of the front-end code-base
+- **`lib/split-text/`** — vendored split-text logic, wrapped by `components/split-text.tsx`
+- **`@novus/password-protection`** (workspace package) — site-wide password gate,
+  registered as React Router middleware in `app/root.tsx`
+- **`@novus/static-i18n`** (workspace package) — build-time static i18n
+- **`@novus/transitions`** (workspace package) — page transition system
 
-```json
-{
-  "path": "./**/*.{ts,tsx,js,jsx}",
-  "schema": "./<front-end-folder>/sanity/extract.json",
-  "generates": "./<web-folder>/sanity/types.ts"
-}
-```
+See `architecture.mdc` § Workspace Packages for the full list and note that
+these previously lived under `lib/` before being extracted to `packages/*`.
 
-#### For the Front-end
-ONLY write Types for document types and query responses if you cannot generate them with Sanity TypeGen
-
-### Project Settings and Data
-ALWAYS check if there is a way to interact with a project via the CLI before writing custom scripts `npx sanity --help`
-
----
-
-## Shopify Integration
-
-### API Configuration
-Use GraphQL for queries. Store credentials securely.
-
-```typescript
-const shopifyClient = createShopifyClient({
-  domain: process.env.SHOPIFY_DOMAIN,
-  storefrontAccessToken: process.env.SHOPIFY_STOREFRONT_TOKEN
-})
-```
-
-### Product Management
-Use fragments for reusable queries. Implement proper error handling.
-
-```typescript
-import { PRODUCT_FRAGMENT } from '@/lib/integrations/shopify/fragments/product'
-```
-
-### Cart Operations
-Use mutations for cart operations. Maintain cart state with Zustand.
-
-```typescript
-import { ADD_TO_CART_MUTATION } from '@/lib/integrations/shopify/mutations/cart'
-```
-
----
-
-## HubSpot Forms
-
-### Form Integration
-Use Server Actions for submissions. Validate data server-side.
-
-```typescript
-export async function submitToHubspot(formData: FormData) {
-  'use server'
-  const client = new HubspotClient({
-    accessToken: process.env.HUBSPOT_ACCESS_TOKEN
-  })
-  // submission logic
-}
-```
-
-### Newsletter Subscriptions
-Implement proper consent management. Handle errors gracefully.
-
-```typescript
-import { HubspotNewsletterAction } from '@/lib/integrations/hubspot/action'
-```
-
----
-
-## General Integration Best Practices
-
-### Environment Variables & Validation
-
-All integrations validate env vars with **Zod schemas**. Never use raw `process.env` -- use the typed `env` object instead.
-
-```typescript
-// Type-safe environment access (preferred over process.env)
-import { env } from '@/lib/env'
-
-const projectId = env.NEXT_PUBLIC_SANITY_PROJECT_ID // string | undefined, with IntelliSense
-```
-
-- Never commit API keys
-- Use `.env.local` for development
-- Document required variables in `.env.example`
-- Each integration defines its own Zod schema in `@/utils/validation`
-- `lib/env.ts` provides a single validated `env` object parsed once at import
-
-### Integration Registry
-
-`lib/integrations/registry.ts` is the **single source of truth** for all integrations. Adding a new integration is 2 steps:
-
-1. Create its Zod env schema in `@/utils/validation`
-2. Add a registry entry in `lib/integrations/registry.ts`
-
-Everything else (check-integration, doctor) picks it up automatically.
-
-```typescript
-import { integrations, isConfigured, getConfigured } from '@/integrations/registry'
-
-// Check if a specific integration is ready
-if (isConfigured('sanity')) { /* ... */ }
-
-// Get all configured integration names
-const active = getConfigured() // ['Sanity', 'HubSpot', ...]
-```
-
-### Server Action Error Pattern
-
-All server actions return a consistent shape. No Map-based errors.
-
-```typescript
-// Standard server action return type
-{ status: number, message: string, fieldErrors?: Record<string, string[]> }
-
-// Example server action with Zod validation
-async function submitForm(formData: FormData) {
-  'use server'
-  const result = schema.safeParse(Object.fromEntries(formData))
-  if (!result.success) {
-    const fieldErrors = result.error.flatten().fieldErrors
-    return { status: 400, message: 'Invalid input', fieldErrors }
-  }
-  // ... process valid data
-  return { status: 200, message: 'Success' }
-}
-```
-
-Server actions validate input with `parseFormData()` (from `@/utils/validation`) or direct `schema.safeParse()`.
-
-### Client/Server Validation Bridge
-
-Use `zodToValidator()` to convert Zod schemas for client-side form validation while keeping the schema as the single source of truth.
-
-```typescript
-import { zodToValidator } from '@/utils/zodToValidator'
-
-// In form hook -- reuses the same Zod schema on the client
-const validate = zodToValidator(myFormSchema)
-```
-
-### API Resilience
-**Always use `fetchWithTimeout` for external API calls**
-
-- Standard timeouts: 8-10 seconds for most integrations
-- Implement proper error handling and retry logic
-- Use `cacheSignal()` for automatic request cleanup (React 19+)
-
-```typescript
-import { fetchWithTimeout } from '@/utils/fetch'
-import { cacheSignal } from 'react'
-
-// HubSpot: 8 seconds
-const response = await fetchWithTimeout(url, { 
-  timeout: 8000,
-  ...options 
-})
-
-// Mailchimp: 10 seconds
-const response = await fetchWithTimeout(url, { 
-  timeout: 10000,
-  ...options 
-})
-
-// With cacheSignal for automatic cleanup
-const signal = cacheSignal()
-const response = await fetchWithTimeout(url, {
-  timeout: 10000,
-  signal: signal as AbortSignal,
-  ...options
-})
-```
-
-### Error Handling
-Implement timeout handling for all API calls. Provide user-friendly error messages. Log errors for debugging with context.
-
-```typescript
-try {
-  const response = await fetchWithTimeout(url, options, 10000)
-  return { data: await response.json(), error: null }
-} catch (error) {
-  console.error('API call failed:', error)
-  return { data: null, error: error.message }
-}
-```
-
-### Type Safety
-Generate TypeScript types from APIs when possible. Use proper validation (e.g., Zod schemas).
-
-```typescript
-import * as z from "zod"; 
-
-const ProductSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  price: z.number()
-})
-```
-
-### Performance
-- Cache API responses appropriately (except user-specific data)
-- Use ISR (Incremental Static Regeneration) for dynamic content
-- Implement proper loading states with Suspense boundaries
-- Use `cacheSignal()` for automatic request cleanup
-
-**⚠️ Cache Components Gotchas:**
-- **User-specific data**: Never cache (carts, accounts, private content)
-- **Real-time data**: Use `cache: 'no-store'` for live feeds
-- **Suspense boundaries**: Required for cached data fetching
-- **Cache invalidation**: Use `revalidateTag()` or `revalidatePath()` in webhooks
-- **Testing**: Test with hard refresh AND navigation (different cache layers)
-
-### Security
-- Validate all user inputs
-- Use server-side API calls for sensitive operations
-- Implement rate limiting where necessary
-
-### Integration Management
-- Check integration usage with `@/lib/integrations/check-integration`
-- Keep only active integrations to optimize bundle size
-- Remove unused integration directories to reduce bundle size
-
-## Webhook Handling
-
-### Verification
-Always verify webhook signatures. Use proper authentication.
-
-```typescript
-export async function verifyWebhookSignature(
-  payload: string,
-  signature: string
-): Promise<boolean> {
-  // verification logic
-}
-```
-
-### Processing
-Process webhooks asynchronously. Implement idempotency. Return 200 status quickly.
-
-Last updated: 2026-02-06
+Last updated: 2026-08-03

--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -6,277 +6,124 @@ description: Project overview and cross-cutting concerns
 globs: *.tsx, *.jsx, *.css, *.js, *.ts
 ---
 
-# Satus Project Guidelines
+# Novus Project Guidelines
 
 ## Technology Stack
 
-- **Next.js 16+** - App Router with Turbopack support and Cache Components
-- **React 19+** - Latest features including `<Activity />`, `useEffectEvent`, and `cacheSignal`
-- **React Compiler** - Automatically optimizes component re-renders and memoization
-- **TypeScript** - Strict mode enabled
-- **Tailwind CSS v4** - CSS-first configuration
-- **Zod** - Schema validation (env vars, forms, server actions)
-- **Biome** - Linting and formatting
-- **Bun** - JavaScript runtime and package manager
+- **React Router 7** - SSR framework (file-based routing via `app/routes.ts`)
+- **React 19** - `ref` as a regular prop, no `forwardRef` needed
+- **React Compiler** - Automatically optimizes re-renders; manual memoization is banned in app code
+- **TypeScript** - Strict mode, `verbatimModuleSyntax: true`
+- **Tailwind CSS v4** - via `@tailwindcss/vite`, combined with CSS Modules and Lightning CSS
+- **Vite 8** - Build tool, with the `darkroom-styling` plugin generating CSS from config
+- **Bun** - Package manager and runtime, workspaces under `packages/*`
+- **Oxlint / Oxfmt** - Linting and formatting (not Biome, not ESLint/Prettier)
 
-## React 19.2 New Features
+## Path Alias
 
-### 1. `<Activity />` Component
-Manage off-screen component visibility and defer updates for better performance.
-
-```tsx
-import { Activity } from 'react'
-
-// Hide tab content when not visible
-<Activity mode={isActive ? 'visible' : 'hidden'}>
-  <ExpensiveComponent />
-</Activity>
-```
-
-**Use Cases:**
-- Tab systems or carousels
-- Off-screen WebGL scenes (3D graphics, shaders)
-- Accordion components
-- Drawer/modal systems
-- Image galleries and carousels
-
-**Benefits:**
-- Pre-render content without performance impact
-- Automatic effect cleanup when hidden
-- Better resource management for complex UIs
-
-### 2. `useEffectEvent` Hook
-Separate event logic from effect dependencies to prevent unnecessary re-runs.
+`~/` maps to the project root. It is the **only** alias.
 
 ```tsx
-import { useEffect, useEffectEvent } from 'react'
-
-function Component({ url, theme }) {
-  const onConnected = useEffectEvent(() => {
-    showNotification('Connected!', theme) // theme changes won't trigger reconnect
-  })
-
-  useEffect(() => {
-    const connection = createConnection(url)
-    connection.on('connected', onConnected)
-    connection.connect()
-    return () => connection.disconnect()
-  }, [url]) // Only reconnect when url changes
-}
+import { Image } from "~/components/image";
+import { clamp } from "~/utils/math";
+import { breakpoints } from "~/styles/layout";
 ```
-
-**Use Cases:**
-- Complex event handlers with multiple dependencies
-- Scroll/transform callbacks
-- WebGL mouse/interaction handlers
-- Animation callbacks
-
-**Benefits:**
-- Reduces unnecessary effect re-runs
-- Cleaner dependency arrays
-- Better separation of concerns
-
-### 3. `cacheSignal` (Server Components Only)
-Provides an `AbortSignal` that triggers when the component's cache scope expires.
-
-```tsx
-import { cacheSignal } from 'react'
-
-async function fetchUserData(id: string) {
-  const signal = cacheSignal() // Auto-aborts on cache expiry
-  const response = await fetch(`/api/users/${id}`, { signal })
-  return response.json()
-}
-```
-
-**Use Cases:**
-- Sanity CMS queries
-- Shopify API calls
-- Any server component data fetching
-- Replace custom timeout logic with automatic cleanup
-
-**Benefits:**
-- Automatic cleanup of stale requests
-- Better resource management
-- Simpler than manual AbortController
-
-### 4. Performance Tracks in Chrome DevTools
-React 19.2 integrates custom performance tracks into Chrome DevTools:
-- **Scheduler Track:** Displays React's workload prioritization
-- **Components Track:** Shows component hierarchy and timing
-
-**Usage:** Open Chrome DevTools → Performance tab → Record a profile → Look for React-specific tracks
 
 ## File Organization
 
 ```
-├── app/                  # Next.js pages and routes
-├── components/           # Shared UI components
-├── lib/                  # Everything non-UI
-│   ├── hooks/           # Custom React hooks
-│   ├── integrations/    # Sanity, Shopify, HubSpot, etc.
-│   ├── webgl/           # 3D graphics (optional)
-│   ├── dev/             # Debug tools - CMD+O (optional)
-│   ├── scripts/         # CLI tools (dev, setup)
-│   ├── styles/          # CSS config & Tailwind
-│   └── *.ts             # Utils, store, metadata...
-└── public/               # Static assets
+app/                  # root.tsx shell, routes.ts, routes/ (route-specific components/)
+components/           # reusable: image, link, wrapper, theme, lenis, marquee, fold,
+                       # scrollbar, real-viewport, scroll-restoration, animejs, split-text,
+                       # progress-text, dev-only
+hooks/                # custom hooks + Zustand store
+utils/                # pure utilities (math, easings, animation, raf, fetch, strings)
+styles/                # design tokens (colors.ts, layout.ts, easings.ts, typography.ts,
+                       # fonts.ts) + generated CSS in styles/css/
+integrations/sanity/  # Sanity client, queries, image utils, session, loader
+lib/                  # split-text (vendored logic; components/split-text.tsx wraps it)
+example/              # reference marketing-site implementation — the default appDirectory (see below)
+env.ts                # t3-env + valibot env validation
+vite.config.ts        # Vite config, Tailwind, Lightning CSS, darkroom-styling plugin
+react-router.config.ts # appDirectory switch (see below)
+packages/              # workspace packages: font-optimizer, image-optimizer, orchestra,
+                       # password-protection, static-i18n, styling, transitions
 ```
 
-> **Mental model:** "If it renders UI, it's in `components/`. Everything else is in `lib/`."
+> **`app/` vs `example/`**: `react-router.config.ts` sets `appDirectory: "example"` by
+> default, so the reference marketing site in `example/` is what actually runs.
+> `app/` holds the minimal starter shell. To start a real project, switch
+> `appDirectory` to `"app"` and delete `example/`.
 
-## Cross-Cutting Concerns
+## Critical Rules
 
-### React Compiler & Memoization
+### Components
+Use `~/components/image` (never raw `<img>`) and `~/components/link` (never raw `<a>`
+or React Router's `<Link>` directly).
 
-**React Compiler is enabled and handles ALL optimization automatically.**
-
-- **DO NOT use `useMemo`, `useCallback`, or `React.memo` in new code.**
-- The compiler optimizes all component re-renders, memoization, and dependencies automatically.
-- Only use manual memoization if you encounter a proven edge case where the compiler cannot optimize (extremely rare).
-- If you see these in existing code, they can likely be removed safely.
-- **CRITICAL EXCEPTION: Use `useRef` for object instantiation** - Creating new object instances on every render creates new references that trigger effects, causing infinite loops.
-- Refer to the [React Compiler documentation](https://react.dev/reference/react/compiler) for edge cases.
+### Wrapper
+Every route wraps its content in `<Wrapper>`. Opt into WebGL and Lenis per page:
 
 ```tsx
-// ❌ DON'T: Manual memoization for simple calculations (compiler handles this)
-const memoizedValue = useMemo(() => computeExpensive(a, b), [a, b])
-const memoizedCallback = useCallback(() => doSomething(a), [a])
+<Wrapper>content</Wrapper>
+<Wrapper webgl>content with 3D</Wrapper>
+<Wrapper lenis={false}>no smooth scroll</Wrapper>
+```
 
-// ✅ DO: Let React Compiler optimize automatically
+### No Manual Memoization
+React Compiler is enabled via `babel-plugin-react-compiler` in `vite.config.ts`.
+
+- **DO NOT use `useMemo`, `useCallback`, or `React.memo`** in app code.
+- **Exception**: `dev/`-equivalent debug tooling (`packages/orchestra`) is excluded
+  from the Compiler's scope and may memoize manually — perf isn't critical there
+  and explicit memoization keeps intent clear.
+
+```tsx
+// DON'T: manual memoization (compiler handles this)
+const value = useMemo(() => computeExpensive(a, b), [a, b])
+
+// DO: let the compiler optimize
 const value = computeExpensive(a, b)
-const handleClick = () => doSomething(a)
-
-// ⚠️ EXCEPTION: Object instantiation MUST use useRef
-// ❌ DON'T: This causes infinite re-renders when passed to effects/deps
-const instance = new SomeClass()
-
-// ✅ DO: Use useRef for object instantiation
-const instanceRef = useRef<SomeClass | null>(null)
-if (!instanceRef.current) {
-  instanceRef.current = new SomeClass(params)
-}
-const instance = instanceRef.current
 ```
 
-### Image Optimization
-
-**Always use the custom Image component for all images.**
-
-- **DO NOT use `next/image` directly**
-- Use `@/components/ui/image` for standard images
-- **In WebGL contexts, use `@/lib/webgl/components/image`** which wraps the custom Image component for DOM fallback and WebGL texture integration
+### `import type` for Type-Only Imports
+`verbatimModuleSyntax: true` in `tsconfig.json` requires explicit `import type`.
 
 ```tsx
-import { Image } from '@/components/ui'
-// For WebGL:
-import { Image as WebGLImage } from '@/lib/webgl/components/image'
+import type { ComponentProps } from "react";
 ```
 
-### Development vs Production
-
-**Console logs are automatically stripped in production** by Next.js compiler (except `console.error` and `console.warn`)
-
-- **Always gate debug UI components** - these are NOT automatically removed
-- **Gate expensive debug computations** - avoid running heavy operations in production
+### Environment Variables
+`PUBLIC_` prefix for client-exposed vars (`import.meta.env`), plain names for
+server-only vars (`process.env`). Both validated together in the root `env.ts`
+with `@t3-oss/env-core` + `valibot`.
 
 ```tsx
-// ✅ Simple logs: Optional to gate (Next.js strips them automatically)
-console.log('Debug info:', data)
+import { env } from "~/env";
 
-// ✅ Better: Gate expensive operations to avoid computation overhead
-if (process.env.NODE_ENV === 'development') {
-  console.log('Heavy computation:', expensiveDebugCalculation())
-}
-
-// ⚠️ REQUIRED: Always gate debug UI components (not auto-removed)
-{process.env.NODE_ENV === 'development' && <DebugPanel />}
-{process.env.NODE_ENV === 'development' && <Stats />}
+const projectId = env.PUBLIC_SANITY_PROJECT_ID; // typed, validated
 ```
 
-**Bundle Size Optimization:**
-- Keep production bundles minimal by excluding dev-only code
-- Use tree-shaking friendly imports
-- Check bundle size impact of new dependencies
-- Debug UI components must be gated (Next.js won't remove them automatically)
+### `@theatre/core` — CJS Default Import Only
+Ships as CJS; named imports fail under Vite's ESM SSR. Always default-import:
+
+```tsx
+import theatreCore from "@theatre/core";
+const { types } = theatreCore;
+```
 
 ## Core Utility Libraries
 
-### Available Utilities
-- **`@/utils/fetch`** - Resilient API calls with `fetchWithTimeout` (default 10s timeout)
-- **`@/utils/metadata`** - Centralized SEO and metadata generation for consistent OpenGraph, Twitter cards, etc.
-- **`@/utils/math`** - Pure math functions: clamp, lerp, mapRange, etc.
-- **`@/utils/animation`** - Animation helpers: fromTo, stagger, spring
-- **`@/utils/strings`** - String utilities: slugify, mergeRefs, etc.
-
-### Usage Examples
-
-```typescript
-// Fetch with timeout
-import { fetchWithTimeout } from '@/utils/fetch'
-const response = await fetchWithTimeout(url, { timeout: 10000, ...options })
-
-// Generate metadata
-import { generatePageMetadata, generateSanityMetadata } from '@/utils/metadata'
-export async function generateMetadata({ params }) {
-  const page = await fetchPage(params.slug)
-  return generateSanityMetadata({ document: page, url: `/page/${params.slug}` })
-}
-
-// Math utilities
-import { clamp, lerp, mapRange } from '@/utils/math'
-const value = clamp(input, 0, 100)
-```
+- **`~/utils/math`** - Pure math functions: clamp, lerp, mapRange, etc.
+- **`~/utils/raf`** - RAF/mutate scheduling helpers (used by real-viewport, etc.)
+- **`~/utils/strings`** - String utilities
+- **`~/utils/fetch`** - Resilient fetch helpers
 
 ## Getting Started
 
-1. Review relevant best practices before starting work in a specific area
-2. Follow the project structure guidelines
-3. Use the provided development tools and debugging features
-4. Consult the documentation for specific implementation details
-5. Use utility libraries for common patterns (API calls, env validation, metadata)
+1. `bun install`, then `bun dev`
+2. Review the relevant rule file before starting work in a specific area
+   (`architecture.mdc`, `components.mdc`, `styling.mdc`, `integrations.mdc`)
+3. Run `bun run check` (lint + format + typecheck) before committing
 
-## Updates
-
-These best practices are regularly updated to reflect:
-- New dependencies and versions
-- Improved patterns and practices
-- Community feedback and learnings
-- Project-specific requirements
-
-## Next.js 16 Cache Components
-
-Cache Components are enabled globally (`cacheComponents: true` in `next.config.ts`). This provides advanced caching strategies for Server Components.
-
-### Important Gotchas
-
-**1. Server Components Only**
-- Cache Components work only in Server Components
-- Client Components (`'use client'`) cannot use Cache Components
-- Move data fetching to Server Components, pass props to Client Components
-
-**2. Suspense Boundaries Required**
-- Cached components must be wrapped in Suspense boundaries
-- Use proper loading fallbacks for better UX
-
-**3. User-Specific Data**
-- ❌ **Never cache** personalized data (user profiles, cart contents, private content)
-- ✅ **Always use** `cache: 'no-store'` for user-specific requests
-- Example: Shopping carts, user accounts, private content
-
-**4. Real-Time Data**
-- Live feeds, stock prices, chat messages should use `cache: 'no-store'`
-- Only cache data that doesn't change frequently
-
-**5. Testing Caching**
-- Hard refresh (`Cmd+Shift+R`) bypasses router cache
-- Normal navigation uses router cache
-- Test both behaviors, especially with dynamic routes
-- Development and production behave differently
-
-**6. Cache Invalidation**
-- Use `revalidateTag()` or `revalidatePath()` in webhook handlers
-- Set proper cache tags: `next: { tags: ['products'] }`
-- Dynamic routes require careful cache tag management
-
-Last updated: 2026-02-06
+Last updated: 2026-08-03

--- a/.cursor/rules/styling.mdc
+++ b/.cursor/rules/styling.mdc
@@ -8,52 +8,42 @@ globs: *.tsx, *.jsx, *.css, *.js, *.ts
 
 # Styling Guidelines
 
+Styling combines **Tailwind CSS v4**, **CSS Modules**, and **Lightning CSS**
+custom functions, driven by the `@novus/styling` workspace package's
+`darkroom-styling` Vite plugin, which generates CSS from `styles/*.ts` config
+on every config change (see `vite.config.ts`).
+
 ## CSS Modules
 
 ### File Naming
-Use kebab-case for CSS module files. Match the component name followed by `.module.css`
-
-```
-button.tsx
-button.module.css
-```
-
-### Class Naming
-Use camelCase for class names. Use descriptive, semantic names.
-
-```css
-.button { /* Base styles */ }
-.isPrimary { /* Variant styles */ }
-.isDisabled { /* State styles */ }
-```
+Kebab-case, matching the component name: `component-name.module.css`.
 
 ### Imports in Components
-Always import CSS modules as `s`
+Always import CSS modules as `s`.
 
 ```tsx
-import s from './component-name.module.css'
+import s from "./component-name.module.css";
 
 function Component() {
-  return <div className={s.wrapper} />
+  return <div className={s.wrapper} />;
 }
 ```
+
+## Design Tokens (`styles/*.ts`)
+
+Design tokens are TypeScript, typed against contracts from `@novus/styling`,
+and are the source the `darkroom-styling` plugin reads to generate CSS:
+
+- **`styles/colors.ts`** — `colors`, `themes` (theme names: `light`, `dark`, `red`, `evil`)
+- **`styles/layout.ts`** — `breakpoints` (`{ dt: 800 }`), `screens`, `layout` (columns/gap/safe), `customSizes`
+- **`styles/easings.ts`** — named easing curves (`in-quad`, `out-expo`, `gleasing`, etc.)
+- **`styles/typography.ts`** — named typography presets (font, size, line-height, letter-spacing)
+- **`styles/fonts.ts`** — font definitions consumed by `@novus/font-optimizer`
 
 ## Responsive Design
 
-### Viewport Functions
-Use custom viewport functions for responsive sizing
-
-```css
-.element {
-  width: mobile-vw(150);      /* 150px at mobile viewport */
-  height: mobile-vh(100);     /* 100px at mobile viewport */
-  margin: desktop-vw(50);     /* 50px at desktop viewport */
-  padding: desktop-vh(25);    /* 25px at desktop viewport */
-}
-```
-
-### Breakpoints
-Desktop breakpoint: 800px (defined in styles/config.ts)
+### Desktop Breakpoint
+`800px`, defined as `breakpoints.dt` in `styles/layout.ts` — not `styles/config.ts`.
 
 ```css
 @media (min-width: 800px) {
@@ -61,124 +51,67 @@ Desktop breakpoint: 800px (defined in styles/config.ts)
 }
 ```
 
+### Lightning CSS Custom Functions
+Registered via `lightningcssFunctions()` in `@novus/styling`, wired into
+`vite.config.ts`'s `css.lightningcss.visitor`:
+
+```css
+.element {
+  width: mobile-vw(150);      /* 150px scaled at mobile viewport width */
+  height: mobile-vh(100);     /* 100px scaled at mobile viewport height */
+  margin: desktop-vw(50);     /* 50px scaled at desktop viewport width */
+  padding: desktop-vh(25);    /* 25px scaled at desktop viewport height */
+  gap: device-vw(20);         /* scales against --device-width (active breakpoint) */
+}
+```
+
 ### Grid System
-Use the column function for grid-based layouts
+Use `columns(n)` for column-based sizing, driven by `--column-width` and `--gap`.
 
 ```css
 .container {
-  width: columns(6);          /* Span 6 columns */
-  margin-left: columns(1);    /* Offset by 1 column */
+  width: columns(6);          /* span 6 columns */
 }
 ```
 
 ## Typography
 
-### Font Hierarchy
-Use typography variables from the theme
+Typography presets from `styles/typography.ts` compile into `dr-*` Tailwind
+utilities (one utility class per preset name) via `generateTailwind()`.
 
 ```css
 .title {
-  font-size: var(--font-size-title);
-  line-height: var(--line-height-title);
-  font-weight: var(--font-weight-bold);
-}
-```
-
-### Text Scaling
-Use scale utilities with the 's' prefix
-
-```css
-.scalingText {
-  --size: 1;
-  font-size: s(var(--size) * 16px);   /* Scales appropriately */
+  @apply test-mono; /* example preset name from styles/typography.ts */
 }
 ```
 
 ## Colors and Themes
 
-### Color Variables
-Use theme colors from CSS variables
+Theme colors compile into `--color-*` CSS variables and Tailwind's `--color-*`
+namespace, overridden per theme via `[data-theme="..."]` selectors and
+`@custom-variant` (so `dark:`, `red:`, `evil:` etc. work as Tailwind variants).
 
 ```css
 .element {
-  color: var(--color-text);
-  background-color: var(--color-background);
-  border-color: var(--color-accent);
+  color: var(--color-primary);
+  background-color: var(--color-secondary);
 }
 ```
 
-### Theme Switching
-Use theme-specific variables when needed
-
-```css
-.element {
-  color: var(--theme-dark-text);
-  background-color: var(--theme-dark-background);
-}
-
-[data-theme="light"] .element {
-  color: var(--theme-light-text);
-  background-color: var(--theme-light-background);
-}
+```tsx
+// Theme is applied via ~/components/theme's ThemeProvider,
+// which sets `data-theme` on <html>.
+<div className="dark:text-white">...</div>
 ```
 
 ## Animations and Transitions
 
-### Transition Timing
-Use consistent transition variables
-
-```css
-.element {
-  transition: opacity var(--transition-duration) var(--transition-ease);
-}
-```
-
-### Animation Easings
-Import easings from the theme
+Import easing names from `styles/easings.ts` (compiled into the `--ease-*`
+Tailwind namespace).
 
 ```css
 .element {
   transition: transform 0.5s var(--ease-out-expo);
-}
-```
-
-## Best Practices
-
-### Performance
-Prefer CPU-friendly properties (transform, opacity). Use `will-change` sparingly and only when needed.
-
-```css
-.animatedElement {
-  will-change: transform, opacity;
-}
-```
-
-### Organization
-Group related properties together. Order properties consistently.
-
-```css
-.element {
-  /* Positioning */
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  
-  /* Box model */
-  display: flex;
-  width: 100%;
-  padding: 1rem;
-  
-  /* Visual */
-  background-color: var(--color-background);
-  border-radius: 4px;
-  
-  /* Typography */
-  font-size: 1rem;
-  color: var(--color-text);
-  
-  /* Animation */
-  transition: all 0.3s ease;
 }
 ```
 
@@ -188,133 +121,42 @@ Group related properties together. Order properties consistently.
 
 ## Core Changes
 
-### CSS-first configuration
-Configuration is now done in CSS instead of JavaScript. Use `@theme` directive in CSS instead of `tailwind.config.js`
+CSS-first configuration — no `tailwind.config.js`. Project config uses
+`@import "tailwindcss"` (via `@tailwindcss/vite`) plus the generated `@theme`
+block from `@novus/styling` (written to `styles/css/`).
 
 ```css
 @import "tailwindcss";
 
 @theme {
-  --font-display: "Satoshi", "sans-serif";
-  --breakpoint-3xl: 1920px;
-  --color-avocado-500: oklch(0.84 0.18 117.33);
-  --ease-fluid: cubic-bezier(0.3, 0, 0, 1);
+  --color-primary: #000000;
+  --breakpoint-dt: 800px;
 }
 ```
 
-### CSS import syntax
-Use `@import "tailwindcss"` instead of `@tailwind` directives
-
-- Old: `@tailwind base; @tailwind components; @tailwind utilities;`
-- New: `@import "tailwindcss";`
-
-### Package changes
-- PostCSS plugin is now `@tailwindcss/postcss` (not `tailwindcss`)
-- CLI is now `@tailwindcss/cli`
-- Vite plugin is `@tailwindcss/vite`
-- No need for `postcss-import` or `autoprefixer` anymore
-
-### Native CSS cascade layers
-Uses real CSS `@layer` instead of Tailwind's custom implementation
+- PostCSS plugin: `@tailwindcss/postcss` — not used here, project uses `@tailwindcss/vite`
+- No `postcss-import` or `autoprefixer` needed
+- Native CSS cascade layers (`@layer`)
 
 ## Theme Configuration
 
-### CSS theme variables
-All design tokens are available as CSS variables
+Namespaces available as CSS variables, most populated by generated tokens:
 
-- Namespace format: `--category-name` (e.g., `--color-blue-500`, `--font-sans`)
-- Access in CSS: `var(--color-blue-500)`
-- Available namespaces:
-  - `--color-*` : Color utilities like `bg-red-500` and `text-sky-300`
-  - `--font-*` : Font family utilities like `font-sans`
-  - `--text-*` : Font size utilities like `text-xl`
-  - `--font-weight-*` : Font weight utilities like `font-bold`
-  - `--tracking-*` : Letter spacing utilities like `tracking-wide`
-  - `--leading-*` : Line height utilities like `leading-tight`
-  - `--breakpoint-*` : Responsive breakpoint variants like `sm:*`
-  - `--container-*` : Container query variants like `@sm:*` and size utilities like `max-w-md`
-  - `--spacing-*` : Spacing and sizing utilities like `px-4` and `max-h-16`
-  - `--radius-*` : Border radius utilities like `rounded-sm`
-  - `--shadow-*` : Box shadow utilities like `shadow-md`
-  - `--inset-shadow-*` : Inset box shadow utilities like `inset-shadow-xs`
-  - `--drop-shadow-*` : Drop shadow filter utilities like `drop-shadow-md`
-  - `--blur-*` : Blur filter utilities like `blur-md`
-  - `--perspective-*` : Perspective utilities like `perspective-near`
-  - `--aspect-*` : Aspect ratio utilities like `aspect-video`
-  - `--ease-*` : Transition timing function utilities like `ease-out`
-  - `--animate-*` : Animation utilities like `animate-spin`
-
-### Simplified theme configuration
-Many utilities no longer need theme configuration
-
-- Utilities like `grid-cols-12`, `z-40`, and `opacity-70` work without configuration
-- Data attributes like `data-selected:opacity-100` don't need configuration
-
-### Dynamic spacing scale
-Derived from a single spacing value
-
-- Default: `--spacing: 0.25rem`
-- Every multiple of the base value is available (e.g., `mt-21` works automatically)
-
-### Overriding theme namespaces
-- Override entire namespace: `--font-*: initial;`
-- Override entire theme: `--*: initial;`
-
-## New Features
-
-### Container query support
-Built-in now, no plugin needed
-
-- `@container` for container context
-- `@sm:`, `@md:`, etc. for container-based breakpoints
-- `@max-md:` for max-width container queries
-- Combine with `@min-md:@max-xl:hidden` for ranges
-
-### 3D transforms
-- `transform-3d` enables 3D transforms
-- `rotate-x-*`, `rotate-y-*`, `rotate-z-*` for 3D rotation
-- `scale-z-*` for z-axis scaling
-- `translate-z-*` for z-axis translation
-- `perspective-*` utilities (`perspective-near`, `perspective-distant`, etc.)
-- `perspective-origin-*` utilities
-- `backface-visible` and `backface-hidden`
-
-### Gradient enhancements
-- Linear gradient angles: `bg-linear-45` (renamed from `bg-gradient-*`)
-- Gradient interpolation: `bg-linear-to-r/oklch`, `bg-linear-to-r/srgb`
-- Conic and radial gradients: `bg-conic`, `bg-radial-[at_25%_25%]`
-
-### Shadow enhancements
-- `inset-shadow-*` and `inset-ring-*` utilities
-- Can be composed with regular `shadow-*` and `ring-*`
-
-### New CSS property utilities
-- `field-sizing-content` for auto-resizing textareas
-- `scheme-light`, `scheme-dark` for `color-scheme` property
-- `font-stretch-*` utilities for variable fonts
+- `--color-*`, `--font-*`, `--text-*`, `--font-weight-*`, `--tracking-*`, `--leading-*`
+- `--breakpoint-*` (`dt: 800px` from `styles/layout.ts`)
+- `--spacing-*` (includes `--spacing-safe`, `--spacing-gap`, and any `customSizes`)
+- `--ease-*` (from `styles/easings.ts`)
 
 ## New Variants
-
-### Composable variants
-Chain variants together
-
-```tsx
-// Example: group-has-data-potato:opacity-100
-```
-
-### New variants
 - `starting` variant for `@starting-style` transitions
-- `not-*` variant for `:not()` pseudo-class
-- `inert` variant for `inert` attribute
-- `nth-*` variants (`nth-3:`, `nth-last-5:`, `nth-of-type-4:`, `nth-last-of-type-6:`)
-- `in-*` variant (like `group-*` but without adding `group` class)
-- `open` variant now supports `:popover-open`
-- `**` variant for targeting all descendants
+- `not-*`, `inert`, `nth-*`, `in-*` variants
+- Theme variants generated per theme name: `dark:`, `red:`, `evil:`, `light:`
 
 ## Custom Extensions
 
-### Custom utilities
-Use `@utility` directive
+Use `@utility` / `@variant` directives for anything project-specific — this is
+how `@novus/styling`'s generators (`generate-tailwind.ts`, `generate-scale.ts`)
+emit the `dr-*` utility classes below.
 
 ```css
 @utility tab-4 {
@@ -322,122 +164,26 @@ Use `@utility` directive
 }
 ```
 
-### Custom variants
-Use `@variant` directive
-
-```css
-@variant pointer-coarse (@media (pointer: coarse));
-@variant theme-midnight (&:where([data-theme="midnight"] *));
-```
-
-### Plugins
-Use `@plugin` directive
-
-```css
-@plugin "@tailwindcss/typography";
-```
-
-## Breaking Changes
-
-### Removed deprecated utilities
-- `bg-opacity-*` → Use `bg-black/50` instead
-- `text-opacity-*` → Use `text-black/50` instead
-- And others: `border-opacity-*`, `divide-opacity-*`, etc.
-
-### Renamed utilities
-- `shadow-sm` → `shadow-xs` (and `shadow` → `shadow-sm`)
-- `drop-shadow-sm` → `drop-shadow-xs` (and `drop-shadow` → `drop-shadow-sm`)
-- `blur-sm` → `blur-xs` (and `blur` → `blur-sm`)
-- `rounded-sm` → `rounded-xs` (and `rounded` → `rounded-sm`)
-- `outline-none` → `outline-hidden` (for the old behavior)
-
-### Default style changes
-- Default border color is now `currentColor` (was `gray-200`)
-- Default `ring` width is now 1px (was 3px)
-- Placeholder text now uses current color at 50% opacity (was `gray-400`)
-- Hover styles only apply on devices that support hover (`@media (hover: hover)`)
-
-### Syntax changes
-- CSS variables in arbitrary values: `bg-(--brand-color)` instead of `bg-[--brand-color]`
-- Stacked variants now apply left-to-right (not right-to-left)
-- Use CSS variables instead of `theme()` function 
-
-## Advanced Configuration
-
-### Using a prefix
-
-```css
-@import "tailwindcss" prefix(tw);
-```
-
-Results in classes like `tw:flex`, `tw:bg-red-500`, `tw:hover:bg-red-600`
-
-### Source detection
-- Automatic by default (ignores `.gitignore` files and binary files)
-- Add sources: `@source "../node_modules/@my-company/ui-lib";`
-- Disable automatic detection: `@import "tailwindcss" source(none);`
-
-### Legacy config files
-
-```css
-@import "tailwindcss";
-@config "../../tailwind.config.js";
-```
-
-### Dark mode configuration
-
-```css
-@import "tailwindcss";
-@variant dark (&:where(.dark, .dark *));
-```
-
-### Container customization
-Extend with `@utility`
-
-```css
-@utility container {
-  margin-inline: auto;
-  padding-inline: 2rem;
-}
-```
-
-### Using `@apply` in Vue/Svelte
-
-```html
-<style>
-  @import "../../my-theme.css" theme(reference);
-  /* or */
-  @import "tailwindcss/theme" theme(reference);
-  
-  h1 {
-    @apply font-bold text-2xl text-red-500;
-  }
-</style>
-```
-
 ---
 
 # Project-Specific Custom Utilities
 
-The project includes custom utility classes and functions generated by scripts in `styles/scripts`. These are available globally in all CSS.
+Generated by `@novus/styling`'s `generate-tailwind.ts` and `generate-scale.ts`,
+consumed automatically wherever Tailwind classes are used. Always check
+`styles/css/` for the current generated output if unsure.
 
-## Custom Utility Classes (`dr-*`)
-
-### Scaling Utilities (responsive to device width)
-- `dr-text-*` — font-size
-- `dr-tracking-*` — letter-spacing
-- `dr-leading-*` — line-height
+## Scaling Utilities (`dr-*`, responsive to device width)
+Generated per-property by `generate-scale.ts`'s `scaleUtilityMap`:
+- `dr-text-*`, `dr-tracking-*`, `dr-leading-*` — typography
 - `dr-border-*`, `dr-border-t-*`, `dr-border-r-*`, `dr-border-b-*`, `dr-border-l-*` — border widths
-- `dr-rounded-*`, `dr-rounded-t-*`, `dr-rounded-r-*`, `dr-rounded-b-*`, `dr-rounded-l-*`, `dr-rounded-tl-*`, `dr-rounded-tr-*`, `dr-rounded-br-*`, `dr-rounded-bl-*` — border radii
+- `dr-rounded-*`, `dr-rounded-t-*`, `dr-rounded-r-*`, `dr-rounded-b-*`, `dr-rounded-l-*`,
+  `dr-rounded-tl-*`, `dr-rounded-tr-*`, `dr-rounded-br-*`, `dr-rounded-bl-*` — border radii
 
-### Column-Based Sizing Utilities (responsive to grid columns)
-- `dr-w-col-*`, `dr-min-w-col-*`, `dr-max-w-col-*` — width, min-width, max-width by columns
-- `dr-h-col-*`, `dr-min-h-col-*`, `dr-max-h-col-*` — height, min-height, max-height by columns
-- `dr-gap-col-*`, `dr-gap-x-col-*`, `dr-gap-y-col-*` — grid gaps by columns
-- `dr-p-col-*`, `dr-px-col-*`, `dr-py-col-*`, `dr-pt-col-*`, `dr-pr-col-*`, `dr-pl-col-*`, `dr-pb-col-*` — padding by columns
-- `dr-m-col-*`, `dr-mx-col-*`, `dr-my-col-*`, `dr-mt-col-*`, `dr-mr-col-*`, `dr-ml-col-*`, `dr-mb-col-*` — margin by columns
+Each also has a negative variant (`-dr-mt-*`) and a `-px` variant (`dr-mt-px`)
+where the property supports it (from `columnUtilityMap`).
 
-### Standard Sizing Utilities (responsive to device width)
+## Standard Sizing Utilities (`dr-*`, responsive to device width)
+From `generate-scale.ts`'s `columnUtilityMap`:
 - `dr-w-*`, `dr-min-w-*`, `dr-max-w-*` — width, min-width, max-width
 - `dr-h-*`, `dr-min-h-*`, `dr-max-h-*` — height, min-height, max-height
 - `dr-gap-*`, `dr-gap-x-*`, `dr-gap-y-*` — grid gaps
@@ -445,23 +191,31 @@ The project includes custom utility classes and functions generated by scripts i
 - `dr-m-*`, `dr-mx-*`, `dr-my-*`, `dr-mt-*`, `dr-mr-*`, `dr-ml-*`, `dr-mb-*` — margin
 - `dr-top-*`, `dr-right-*`, `dr-bottom-*`, `dr-left-*`, `dr-inset-*`, `dr-inset-x-*`, `dr-inset-y-*` — positioning
 
-### Layout and Grid Utilities
-- `dr-grid` — sets display: grid and grid-template-columns based on project columns
-- `dr-layout-block` — sets margin-inline and width for layout blocks
-- `dr-layout-block-inner` — sets padding-inline and width for inner layout blocks
-- `dr-layout-grid` — combines layout block and grid
-- `dr-layout-grid-inner` — combines inner layout block and grid
-- `desktop-only` — hides element on mobile
-- `mobile-only` — hides element on desktop
+## Column-Based Sizing Utilities (`dr-*-col-*`, responsive to grid columns)
+Same property list as above, suffixed `-col-`:
+- `dr-w-col-*`, `dr-min-w-col-*`, `dr-max-w-col-*`
+- `dr-gap-col-*`, `dr-p-col-*`, `dr-m-col-*`, etc.
 
-## Custom PostCSS Functions
-- `mobile-vw(pixels)` — converts pixels to viewport width for mobile
-- `mobile-vh(pixels)` — converts pixels to viewport height for mobile
-- `desktop-vw(pixels)` — converts pixels to viewport width for desktop
-- `desktop-vh(pixels)` — converts pixels to viewport height for desktop
-- `columns(n)` — calculates width based on number of grid columns
+## Layout and Grid Utilities
+From `generate-tailwind.ts`:
+- `dr-grid` — `display: grid` + `grid-template-columns` from `--columns` / `--gap`
+- `dr-layout-block` — centers content, width based on `--safe`
+- `dr-layout-block-inner` — inner padding based on `--safe`
+- `dr-layout-grid` — `dr-layout-block` + `dr-grid`
+- `dr-layout-grid-inner` — `dr-layout-block-inner` + `dr-grid`
+- `desktop-only` — hides element on mobile (`@media (--mobile)`)
+- `mobile-only` — hides element on desktop (`@media (--desktop)`)
+
+## Custom Lightning CSS Functions
+From `packages/styling/lightningcss-functions.ts`:
+- `mobile-vw(px)` / `mobile-vh(px)` — scale against `--mobile-width` / `--mobile-height`
+- `desktop-vw(px)` / `desktop-vh(px)` — scale against `--desktop-width` / `--desktop-height`
+- `device-vw(px)` / `device-vh(px)` — scale against the active `--device-width` / `--device-height`
+- `columns(n)` — width based on `--column-width` and `--gap`
 
 ## Theme and Utility Generation
-The theme, utilities, and variants are generated from project config and may differ from vanilla Tailwind. Always check `/styles/css/tailwind.css` for the latest generated classes.
+The theme, utilities, and variants are generated from `styles/*.ts` config —
+not written by hand. Always check `styles/css/` (`index.css`, `global.css`,
+`reset.css`) for the current generated output before assuming a class exists.
 
-Last updated: 2025-12-18
+Last updated: 2026-08-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Satus -- AI Agent Guide
+# Novus — AI Agent Guide
 
 React Router starter by [darkroom.engineering](https://darkroom.engineering).
 
@@ -22,7 +22,8 @@ lib/                    # Opt-in modules: password-protection, transitions, stat
 dev/                    # Debug tools (Orchestra, grid, stats, minimap, Theatre.js)
 webgl/                  # 3D graphics system (R3F, global canvas, tunnels)
 example/                # Reference implementation (home, features, about, nav, preloader,
-                        # transitions). Copy what you need into app/ — not wired by default.
+                        # transitions). The DEFAULT appDirectory (react-router.config.ts) —
+                        # switch to app/ and delete example/ to start a real project.
 env.ts                  # Env (t3-env + valibot, PUBLIC_ prefix for client, plain for server)
 vite.config.ts          # Vite config, Tailwind, Lightning CSS, darkroom-styling plugin
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright (c) 2024 darkroom.engineering
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/PROD-README.md
+++ b/PROD-README.md
@@ -47,4 +47,4 @@ Push to `main` branch for Vercel deployment.
 
 ---
 
-Built with [Satus](https://github.com/darkroomengineering/satus) by [darkroom.engineering](https://darkroom.engineering)
+Built with [Novus](https://github.com/darkroomengineering/novus) by [darkroom.engineering](https://darkroom.engineering)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-[![SATUS](https://assets.darkroom.engineering/satus/banner.gif)](https://github.com/darkroomengineering/satus)
+# Novus
 
-# Satus
-
-A React Router starter with React 19, Tailwind CSS v4, and optional WebGL. _Satus_ means "beginning" in Latin.
+A React Router starter with React 19, Tailwind CSS v4, and optional WebGL. _Novus_ means "new" in Latin.
 
 ## Requirements
 
@@ -18,6 +16,8 @@ bun install
 cp .env.example .env.local
 bun dev
 ```
+
+> `bun dev` serves the bundled `example/` marketing site by default. To start your own app, point `appDirectory` at `app/` in `react-router.config.ts` and delete `example/`.
 
 ## Tech Stack
 
@@ -40,6 +40,14 @@ styles/                 # Design system, Tailwind config, CSS generation
 integrations/           # Third-party services (Sanity)
 dev/                    # Debug tools (Orchestra, Theatre.js)
 webgl/                  # 3D graphics system (R3F)
+packages/               # Workspace packages
+  font-optimizer/       # Vite plugin: font subsetting/optimization
+  image-optimizer/      # Vite plugin: image processing
+  orchestra/            # Dev debug panel (grid, stats, minimap, Theatre.js studio)
+  password-protection/  # Site-wide password gate middleware
+  static-i18n/          # Static i18n build + loader
+  styling/              # darkroom-styling Vite plugin, CSS/design-token codegen
+  transitions/          # Page-transition system
 ```
 
 ## Commands

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@darkroom.engineering/satus",
+      "name": "@darkroom.engineering/novus",
       "dependencies": {
         "@novus/font-optimizer": "workspace:*",
         "@novus/orchestra": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@darkroom.engineering/satus",
+  "name": "@darkroom.engineering/novus",
   "version": "2.0.0",
   "private": true,
   "description": "React Router starter by darkroom.engineering",
@@ -85,5 +85,9 @@
     "iOS >= 16",
     "Safari >= 16",
     "not dead"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "packageManager": "bun@1.3.5"
 }


### PR DESCRIPTION
## What this does

Novus was still wearing satus's clothes in a few places that matter. The package was literally named `@darkroom.engineering/satus`, and the `.cursor/rules/` files were satus's Next.js rules copied wholesale — they told any agent working here that this is a Next.js 16 App Router repo with Shopify and HubSpot integrations, none of which exists in novus. Agents reading those rules were being actively misled. Both are fixed, plus the smaller identity gaps: no LICENSE file despite declaring MIT, no engines field despite the README requiring Node 22, and docs that predate the packages/* workspace.

## Summary

Review order: `package.json` first, then `.cursor/rules/integrations.mdc` (the worst offender), then the rest.

1. Root package renamed to `@darkroom.engineering/novus`; bun.lock's mirrored name synced (verified with `bun install --frozen-lockfile` → no changes); `engines` node >=22 + `packageManager` bun@1.3.5 added; MIT `LICENSE` added (org wording from satus).
2. All six `.cursor/rules/` files rewritten against the actual code: React Router 7 loaders, `PUBLIC_*` env vars from `env.ts`, `integrations/sanity/` path, the packages/* workspace, real component inventory. Every carried-over claim was verified in-repo; unverifiable ones dropped (~1,400 lines removed). Cross-model review caught four factual errors in the first pass (wrong postprocessing package, wrong dev-tools gating mechanism, a phantom `components/animejs`, one self-contradiction) — all fixed.
3. README/CLAUDE.md: retitled to Novus, `bun dev`-serves-`example/` behavior documented in Quick Start, packages/* listed in project structure, and the stale "example/ not wired by default" claim corrected — `appDirectory: "example"` makes it the default.

Deliberately untouched: the "Satus" branding inside `example/` (nav labels, page titles, marketing copy). That's the demo site's content — renaming it is a content decision, not a correctness fix, and it disappears the moment a real project deletes `example/`.

## Test plan

- [ ] `bun run check` → exit 0 (oxlint + oxfmt + typegen + tsc)
- [ ] `bun install --frozen-lockfile` → no changes
- [ ] `grep -rniE "nextjs|NEXT_PUBLIC|shopify|hubspot|Satus" .cursor/rules/` → zero matches
- [ ] `grep '"name"' package.json bun.lock` → both say novus
